### PR TITLE
Allow number scale to go negative as per configuration

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -662,7 +662,7 @@ making sure that you maintain a proper JSON format.
 				"propertyTooltip": "Setting for Scale must be between -84 and 127",
 				"minValue": -84,
 				"maxValue": 127,
-				"allowNegative": false,
+				"allowNegative": true,
 				"typeDecorator": true,
 				"dependency": {
 					"type": "and",


### PR DESCRIPTION
I noticed on the Application it wasn't possible to set a negative scale as per Oracle documentation.