### PR TITLE
HCK-3340: Oracle plugin JSON support for other datatypes than just object

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1886,8 +1886,14 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "subtype",
 				"propertyTooltip": "needs for configuration of json types",
 				"propertyType": "select",
-				"options": ["json"],
-				"hidden": true
+				"options": [
+					{ "name": "object", "value": "object" },
+					{ "name": "array", "value": "array" },
+					{ "name": "string", "value": "string" },
+					{ "name": "number", "value": "number" },
+					{ "name": "boolean", "value": "boolean" },
+					{ "name": "null", "value": "null" }
+				]
 			},
 			{
 				"propertyName": "JSON Type",

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -103,7 +103,7 @@ module.exports = {
 						progress({ message: `Fetching columns for JSON schema inference: ${JSON.stringify(jsonColumns)}`, containerName: schema, entityName: table });
 
 						documents = await oracleHelper.selectRecords({ tableName: table, limit: quantity, jsonColumns, schema });
-						documents = _.map(documents, obj => _.omitBy(obj, _.isNull));
+						//documents = _.map(documents, obj => _.omitBy(obj, _.isNull));
 						jsonSchema = await oracleHelper.getJsonSchema(jsonColumns, documents);
 					}
 					

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -103,7 +103,6 @@ module.exports = {
 						progress({ message: `Fetching columns for JSON schema inference: ${JSON.stringify(jsonColumns)}`, containerName: schema, entityName: table });
 
 						documents = await oracleHelper.selectRecords({ tableName: table, limit: quantity, jsonColumns, schema });
-						//documents = _.map(documents, obj => _.omitBy(obj, _.isNull));
 						jsonSchema = await oracleHelper.getJsonSchema(jsonColumns, documents);
 					}
 					

--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -693,11 +693,13 @@ const getJsonSchema = async (jsonColumns, records) => {
 			return properties;
 		}
 
+		const type = `${schema.type}${subtype.charAt(0).toUpperCase()}${subtype.slice(1)}`
 		return {
 			...properties,
 			[columnName]: {
 				...schema,
 				subtype,
+				type
 			}
 		};
 	}, {});

--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -574,7 +574,6 @@ const getDDL = async (tableName, schema, logger) => {
 		if(err?.errorNum === 31603 && !(await checkUserHaveRequiredRole(logger))) {
 			throw err;
 		}
-		console.log(err);
 
 		logger.log('error', {
 			message: 'Cannot get DDL for table: ' + tableName,

--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -670,6 +670,10 @@ const getJsonType = (records, columnName) => {
 	}, '');
 };
 
+const getJsonTypeName = (type) => {
+	return `json${type.charAt(0).toUpperCase()}${type.slice(1)}`
+}
+
 const getJsonSchema = async (jsonColumns, records) => {
 	const types = {
 		CLOB: { type: 'lobs', mode: 'clob' },
@@ -692,7 +696,7 @@ const getJsonSchema = async (jsonColumns, records) => {
 			return properties;
 		}
 
-		const type = `${schema.type}${subtype.charAt(0).toUpperCase()}${subtype.slice(1)}`
+		const type = getJsonTypeName(subtype)
 		return {
 			...properties,
 			[columnName]: {

--- a/types/json.json
+++ b/types/json.json
@@ -35,10 +35,10 @@
 		"maxProperties": "",
 		"additionalProperties": false,
 		"enum": [],
-		"subtype": "json"
+		"subtype": "object"
 	},
 	"subtypes": {
-		"json": {
+		"object": {
 			"parentType": "jsonObject",
 			"childValueType": [
 				"jsonString",
@@ -48,6 +48,29 @@
 				"jsonBoolean",
 				"jsonNull"
 			]
+		},
+		"array": {
+			"parentType": "jsonArray",
+			"childValueType": [
+				"jsonString",
+				"jsonNumber",
+				"jsonObject",
+				"jsonArray",
+				"jsonBoolean",
+				"jsonNull"
+			]
+		},
+		"string": {
+			"parentType": "jsonString"
+		},
+		"number": {
+			"parentType": "jsonNumber"
+		},
+		"boolean": {
+			"parentType": "jsonBoolean"
+		},
+		"null": {
+			"parentType": "jsonNull"
 		}
 	}
 }


### PR DESCRIPTION
**Content**
Fixed Oracle absence of json subtypes in json typed field

**Affected paths**
PP

**Technical details**
Enabled subtypes select on PP and added json subtypes recognition logic


