### PR TITLE
HCK-3612: add use schema statement to fix not found UDT while applying to instance

### DIFF
--- a/forward_engineering/configs/templates.js
+++ b/forward_engineering/configs/templates.js
@@ -1,6 +1,8 @@
 module.exports = {
     createSchema: 'CREATE USER ${schemaName} NO AUTHENTICATION',
 
+    useSchema: 'ALTER SESSION SET CURRENT_SCHEMA=${schemaName};',
+
     comment: '\nCOMMENT ON ${object} ${objectName} IS ${comment};\n',
 
     createTable:

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -116,7 +116,10 @@ module.exports = (baseProvider, options, app) => {
 				ifNotExist,
 				1920,
 			);
-			return schemaStatement;
+			const useSchemaStatement = assignTemplates(templates.useSchema, {
+				schemaName: wrapInQuotes(schemaName),
+			});
+			return schemaStatement + '\n' + useSchemaStatement;
 		},
 
 		hydrateColumn({ columnDefinition, jsonSchema, schemaData, definitionJsonSchema = {} }) {


### PR DESCRIPTION
Added *use schema* statement (`ALTER SESSION SET CURRENT_SCHEMA="<schema_name>"`) for Oracle DDL FE to fix not found UDTs while creating a table with UDT columns.