### PR TITLE
HCK-3612 :use schema name when referencing UDTs

### DIFF
--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -132,7 +132,8 @@ module.exports = (baseProvider, options, app) => {
 
 		hydrateColumn({ columnDefinition, jsonSchema, schemaData, definitionJsonSchema = {} }) {
 			const dbVersion = schemaData.dbVersion;
-			const type = jsonSchema.$ref ? columnDefinition.type : _.toUpper(jsonSchema.mode || jsonSchema.type);
+			const isUDTRef = !!jsonSchema.$ref;
+			const type = isUDTRef ? columnDefinition.type : _.toUpper(jsonSchema.mode || jsonSchema.type);
 			return {
 				name: columnDefinition.name,
 				type,
@@ -162,6 +163,7 @@ module.exports = (baseProvider, options, app) => {
 				encryption: jsonSchema.encryption,
 				identity: jsonSchema.identity,
 				synonyms: schemaData?.synonyms?.filter(synonym => synonym.synonymEntityId === jsonSchema.GUID) || [],
+				isUDTRef,
 			};
 		},
 

--- a/forward_engineering/helpers/columnDefinitionHelper.js
+++ b/forward_engineering/helpers/columnDefinitionHelper.js
@@ -147,6 +147,8 @@ module.exports = ({
                 return intervalYear(columnDefinition.yearPrecision);
             case (isIntervalDay(type)):
                 return intervalDay(columnDefinition.dayPrecision, columnDefinition.fractSecPrecision);
+            case (!!(columnDefinition.isUDTRef && columnDefinition.schemaName)):
+                return ` "${columnDefinition.schemaName}".${type}`;
             default:
                 return ` ${type}`;
         }


### PR DESCRIPTION
Added explicit use of schema name when referencing a UDT: <“schema_name”>.<UDT_name> to be consistent with other statements.