### PR TITLE
RE: remove the explicit definition of the noshard option for the sequ…

### DIFF
--- a/reverse_engineering/helpers/getSchemaSequences.js
+++ b/reverse_engineering/helpers/getSchemaSequences.js
@@ -55,7 +55,7 @@ const SEQUENCE_OPTION_MAP = {
   },
   [SEQUENCE_OPTION.shard]: {
     [OPTION_VALUE.true]: SEQUENCE_OPTION.shard,
-    [OPTION_VALUE.false]: SEQUENCE_OPTION.noShard,
+    [OPTION_VALUE.false]: '',
   },
   [SEQUENCE_OPTION.scale]: {
     [OPTION_VALUE.true]: SEQUENCE_OPTION.scale,


### PR DESCRIPTION
RE from instance: The explicit definition of the `noshard` sequence option has been removed to avoid errors when applying to instance if the shard of ddl is disabled on the server