### PR TITLE
Hck-5358 HCK-5359: Double "Create Index" statement (all cases: new/existing entities) in ALTER script

### DIFF
--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -90,7 +90,7 @@ const getAlterCollectionsScriptDtos = ({
                                     
     const createCollectionsScriptDtos = createScriptsData.filter(collection => collection.compMod?.created).map(getAddCollectionScriptDto({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
     const deleteCollectionScriptDtos = deleteScriptsData.filter(collection => collection.compMod?.deleted).map(getDeleteCollectionScriptDto(app));
-    const modifyCollectionsScriptDtos = modifyScriptsData.filter(collection => collection.compMod?.modified).flatMap(getModifyCollectionScriptDtos({app, dbVersion}))
+    const modifyCollectionScriptDtos = modifyScriptsData.filter(collection => collection.compMod?.modified).flatMap(getModifyCollectionScriptDtos({app, dbVersion}))
     const addColumnScriptDtos = createScriptsData.filter(item => !item?.compMod?.created).flatMap(getAddColumnScriptDtos({app, dbVersion, modelDefinitions, internalDefinitions, externalDefinitions}));
     const deleteColumnScriptDtos = deleteScriptsData.filter(item => !item?.compMod?.deleted).flatMap(getDeleteColumnScriptDtos(app));
     const modifyColumnScriptDtos = modifyScriptsData.flatMap(getModifyColumnScriptDtos(app, dbVersion));
@@ -98,10 +98,10 @@ const getAlterCollectionsScriptDtos = ({
     return [
         ...createCollectionsScriptDtos,
         ...deleteCollectionScriptDtos,
+        ...modifyCollectionScriptDtos,
         ...addColumnScriptDtos,
         ...deleteColumnScriptDtos,
         ...modifyColumnScriptDtos,
-        ...modifyCollectionsScriptDtos,
     ].filter(Boolean);
 };
 

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -131,7 +131,7 @@ const getAddColumnScriptDtos =
  * @return {AlterScriptDto[]}
  * */
 const getIndexesBasedOnNewlyCreatedColumnsScript = ({_, ddlProvider, dbVersion, collection}) => {
-    const newIndexes = collection?.role?.compMod?.Indxs?.new || collection?.role?.Indxs || []
+    const newIndexes = collection?.role?.Indxs || []
     const newPropertiesIds = Object.values(collection?.properties ?? {}).map(({GUID}) => GUID)
 
     if (newIndexes.length === 0 || newPropertiesIds.length === 0) {

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -1,7 +1,7 @@
 const {AlterScriptDto} = require("../types/AlterScriptDto");
 const {getUpdateTypesScriptDtos} = require("./columnHelpers/alterTypeHelper");
 const {getRenameColumnScriptDtos} = require("./columnHelpers/renameColumnHelper");
-const { getModifyIndexesScriptDtos } = require("./entityHelpers/indexesHelper");
+const { getModifyIndexesScriptDtos, getAddedIndexesScriptDtos } = require("./entityHelpers/indexesHelper");
 
 /**
  * @return {(collection: AlterCollectionDto) => AlterScriptDto | undefined}
@@ -144,7 +144,7 @@ const getIndexesBasedOnNewlyCreatedColumnsScript = ({_, ddlProvider, dbVersion, 
         return []
     }
 
-    return getModifyIndexesScriptDtos({ _, ddlProvider })({ collection, dbVersion })
+    return getAddedIndexesScriptDtos({ _, ddlProvider })({ collection })
 }
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
@@ -142,7 +142,7 @@ const getDeleteIndexScriptDto =
 const getAddedIndexesScriptDtos =
 	({ _, ddlProvider }) =>
 	({ collection }) => {
-		const newIndexes = collection?.role?.compMod?.Indxs?.new || collection?.role?.Indxs || [];
+		const newIndexes = collection?.role?.Indxs || [];
 		const oldIndexes = collection?.role?.compMod?.Indxs?.old || [];
 
 		const addedIndexes = newIndexes.filter(newIndex => {
@@ -276,4 +276,5 @@ const getModifyIndexesScriptDtos =
 
 module.exports = {
 	getModifyIndexesScriptDtos,
+	getAddedIndexesScriptDtos,
 };


### PR DESCRIPTION
oracle double create index statement all cases new existing entities in alter script

This PR also fixes https://hackolade.atlassian.net/browse/HCK-5359?atlOrigin=eyJpIjoiZGRlYzk4NDY5NWMxNDQ2MmExYTk0NGZiZjdhYTMxZDIiLCJwIjoiaiJ9