### PR TITLE
HCK-6960: Oracle: Make sub-type and synonym of array items inherited from the vector type subtype

### DIFF
--- a/types/vector.json
+++ b/types/vector.json
@@ -11,16 +11,21 @@
 	},
 	"subtypes": {
 		"vector": {
-			"childValueType": "number"
+			"childValueType": "number",
+			"childValueMode": "number"
 		},
 		"vector<int8>": {
-			"childValueType": "number"
+			"childValueType": "number",
+			"childValueMode": "number",
+			"childValueSynonym": "int"
 		},
 		"vector<float32>": {
-			"childValueType": "number"
+			"childValueType": "number",
+			"childValueMode": "float"
 		},
 		"vector<float64>": {
-			"childValueType": "number"
+			"childValueType": "number",
+			"childValueMode": "float"
 		}
 	},
 	"compatibleWith": {

--- a/types/vector.json
+++ b/types/vector.json
@@ -12,7 +12,7 @@
 	"subtypes": {
 		"vector": {
 			"childValueType": "number",
-			"childValueMode": "number"
+			"childValueMode": ["number", "float"]
 		},
 		"vector<int8>": {
 			"childValueType": "number",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-6960" title="HCK-6960" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-6960</a>  Make sub-type and synonym of array items inherited from the vector type subtype
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
