### PR TITLE
HCK-7021: updated derivment adapter config to infer synonym

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -65,6 +65,14 @@
 						}
 					}
 				]
+			],
+			[
+				"inferSynonymByType",
+				{
+					"typeName": "childType",
+					"typeValue": "integer",
+					"synonymValue": "integer"
+				}
 			]
 		]
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7021" title="HCK-7021" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-7021</a>  On derive from Polyglot convert integer type to corresponding synonym in Oracle 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Updated derivment adapter config to infer synonym