### PR TITLE
HCK-7174: Oracle: Integer(long) derived from Polyglot: Wrong type displayed

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -50,6 +50,15 @@
 					"synonym": "integer"
 				}
 			},
+			{
+				"from": {
+					"type": "integer",
+					"mode": "long"
+				},
+				"to": {
+					"synonym": ""
+				}
+			},
 			[
 				"renameBlockItemProperties",
 				{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7174" title="HCK-7174" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-7174</a>  Oracle: Integer(long) derived from Polyglot: Wrong type displayed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

The first modifier (from `type: integer` to `synonym: integer`) is not suitable for the following case:

```json
{
  "type": "integer",
  "mode": "long"
}
```

because it should be converted to:

```json
{
  "type": "binary",
  "mode": "long"
}
```

where the `binary` type does not have `synonym: integer`.

So the Polyglot `integer` type will be adapted to Oracle `synonym: integer`, but if it's the Polyglot `long` mode then the `synonym` will be reset.

The modifiers' order matters in this case!

**p.s.** I could explicitly list all of Polyglot's modes so that it strictly defines which modes can be converted using `synonym: integer`. But this and my solution have pros and cons. In this case, I chose less code.