### PR TITLE
chore: update oracledb package to latest

### DIFF
--- a/esbuild.package.js
+++ b/esbuild.package.js
@@ -25,7 +25,15 @@ esbuild
 		outdir: RELEASE_FOLDER_PATH,
 		minify: true,
 		logLevel: 'info',
-		external: ['lodash'],
+		external: [
+			'lodash',
+			'@azure/app-configuration',
+			'@azure/identity',
+			'@azure/keyvault-secrets',
+			'oci-common',
+			'oci-objectstorage',
+			'oci-secrets',
+		],
 		plugins: [
 			clean({
 				patterns: [DEFAULT_RELEASE_FOLDER_PATH],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "Oracle",
-	"version": "0.2.7",
+	"version": "0.2.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Oracle",
-			"version": "0.2.7",
+			"version": "0.2.12",
 			"dependencies": {
 				"adm-zip": "0.5.9",
 				"lodash": "4.17.21",
-				"oracledb": "6.0.3",
+				"oracledb": "6.6.0",
 				"perplex": "0.11.0"
 			},
 			"devDependencies": {
@@ -3391,9 +3391,9 @@
 			}
 		},
 		"node_modules/oracledb": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/oracledb/-/oracledb-6.0.3.tgz",
-			"integrity": "sha512-szsaTgEcVpmGwi5sCHLXvvpoL5ZJIE69wSOBpclsGO5XX6QMce6KRr+R+t68ihns+8MV4A0J4oeR6efCfxScrg==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/oracledb/-/oracledb-6.6.0.tgz",
+			"integrity": "sha512-T3dx+o3j+tVN53wQyr4yGTmoPHLy+a2V8yb1T2PmWrsj3ZlSt2Yu1BgV2yTDqnmBZYpRi/I3yJXRCOHHD7PiyA==",
 			"hasInstallScript": true,
 			"engines": {
 				"node": ">=14.6"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "dependencies": {
         "adm-zip": "0.5.9",
         "lodash": "4.17.21",
-        "oracledb": "6.0.3",
+        "oracledb": "6.6.0",
         "perplex": "0.11.0"
     },
     "lint-staged": {


### PR DESCRIPTION
## Technical details

* upgraded to latest ([6.6.0](https://node-oracledb.readthedocs.io/en/latest/release_notes.html#node-oracledb-v6-6-0-25-jul-2024)), no breaking changes
* tests: [link](https://teamcity.hackolade.com/buildConfiguration/RunTests_Plugins_RunPrTestsPlugins/87889?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildDeploymentsSection=false&expandBuildChangesSection=false)