### PR TITLE
HCK-7953: fix CREATE VIEW statement in alter script when attributes changed

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
@@ -43,10 +43,7 @@ const getAddViewScriptDto = (app, scriptFormat) => view => {
 	if (view.duality) {
 		return getDualityViewScriptDto(app, scriptFormat)(view);
 	}
-	if (view.selectStatement) {
-		return getAddRegularViewScriptDto(app, scriptFormat)(view);
-	}
-	return undefined;
+	return getAddRegularViewScriptDto(app, scriptFormat)(view);
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
@@ -13,7 +13,12 @@ const getAddRegularViewScriptDto = (app, scriptFormat) => view => {
 	);
 	const viewData = {
 		name: view.code || view.name,
-		keys: [],
+		keys: getKeys({
+			view,
+			collectionRefsDefinitionsMap: view.compMod?.collectionData?.collectionRefsDefinitionsMap ?? {},
+			ddlProvider,
+			app,
+		}),
 		schemaData: { schemaName: '' },
 	};
 	const hydratedView = ddlProvider.hydrateView({ viewData, entityData: [view] });
@@ -55,6 +60,45 @@ const getDeleteViewScriptDto = (app, scriptFormat) => view => {
 
 	const dropViewScript = `DROP VIEW ${ddlViewName};`;
 	return AlterScriptDto.getInstance([dropViewScript], true, true);
+};
+
+const getKeys = ({ view, collectionRefsDefinitionsMap, ddlProvider, app }) => {
+	const { mapProperties } = app.require('@hackolade/ddl-fe-utils');
+
+	return mapProperties(view, (propertyName, schema) => {
+		const definition = collectionRefsDefinitionsMap[schema.refId];
+
+		if (!definition) {
+			return ddlProvider.hydrateViewColumn({
+				name: propertyName,
+				isActivated: schema.isActivated,
+			});
+		}
+
+		const entityName =
+			_.get(definition.collection, '[0].code', '') ||
+			_.get(definition.collection, '[0].collectionName', '') ||
+			'';
+		const dbName = _.get(definition.bucket, '[0].code') || _.get(definition.bucket, '[0].name', '');
+		const name = definition.name;
+
+		if (name === propertyName) {
+			return ddlProvider.hydrateViewColumn({
+				name,
+				dbName,
+				entityName,
+				isActivated: schema.isActivated,
+			});
+		}
+
+		return ddlProvider.hydrateViewColumn({
+			name,
+			dbName,
+			entityName,
+			alias: propertyName,
+			isActivated: schema.isActivated,
+		});
+	});
 };
 
 module.exports = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7953" title="HCK-7953" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-7953</a>  Generate difference from fields in views
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Fixed `CREATE VIEW` statement in Alter script when the view has no `selectStatement` (it will be generated from attributes)