### PR TITLE
[HCK-7986]Fix wallet connection screen to ask the walletPassword and remove the need for the serviceName as it can be loaded from tnsnames.ora

### DIFF
--- a/reverse_engineering/connection_settings_modal/connectionSettingsModalConfig.json
+++ b/reverse_engineering/connection_settings_modal/connectionSettingsModalConfig.json
@@ -150,17 +150,19 @@
 				"description": "Specify the service name of the Oracle Instance",
 				"inputType": "text",
 				"dependency": {
-					"type": "or",
-					"values": [
-						{
-							"key": "identifierType",
-							"value": "serviceName"
-						},
-						{
-							"key": "connectionMethod",
-							"value": ["Wallet", "TNS"]
-						}
-					]
+					"key": "connectionMethod",
+					"value": ["TNS"]
+				}
+			},
+			{
+				"inputLabel": "Wallet Password",
+				"inputKeyword": "walletPassword",
+				"description": "Specify the password used to protect the wallet",
+				"inputType": "text",
+				"isHiddenKey": true,
+				"dependency": {
+					"key": "connectionMethod",
+					"value": ["Wallet"]
 				}
 			},
 			{

--- a/reverse_engineering/connection_settings_modal/connectionSettingsModalConfig.json
+++ b/reverse_engineering/connection_settings_modal/connectionSettingsModalConfig.json
@@ -158,7 +158,7 @@
 				"inputLabel": "Wallet Password",
 				"inputKeyword": "walletPassword",
 				"description": "Specify the password used to protect the wallet",
-				"inputType": "text",
+				"inputType": "password",
 				"isHiddenKey": true,
 				"dependency": {
 					"key": "connectionMethod",

--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -25,7 +25,7 @@ const parseProxyOptions = (proxyString = '') => {
 };
 
 const getTnsNamesOraFile = configDir => {
-	return [
+	const tnsNamesOraFile = [
 		configDir,
 		process.env.TNS_ADMIN,
 		path.join(process.env.ORACLE_HOME || '', 'network', 'admin'),
@@ -43,6 +43,8 @@ const getTnsNamesOraFile = configDir => {
 			return filePath;
 		}
 	}, '');
+
+	return tnsNamesOraFile;
 };
 
 const parseTnsNamesOra = filePath => {
@@ -63,16 +65,24 @@ const getConnectionStringByTnsNames = (configDir, serviceName, proxy, logger) =>
 	const tnsData = parseTnsNamesOra(filePath);
 
 	logger({ message: 'tnsnames.ora successfully parsed' });
+	const tnsServicesNames = Object.keys(tnsData);
 
-	if (!tnsData[serviceName]) {
-		logger({ message: 'Cannot find "' + serviceName + '" in tnsnames.ora' });
-
+	if (!tnsData[serviceName] && tnsServicesNames.length === 0) {
+		logger({ message: `Cannot find '${serviceName}' in tnsnames.ora: ${tnsData} and no fallback found` });
 		return serviceName;
 	}
 
-	const address = tnsData[serviceName]?.data?.description?.address;
-	const service = tnsData[serviceName]?.data?.description?.connect_data?.service_name;
-	const sid = tnsData[serviceName]?.data?.description?.connect_data?.sid;
+	const [firstTnsServiceName, ...otherServices] = tnsServicesNames;
+	const tnsService = tnsData[serviceName] || tnsData[firstTnsServiceName];
+	if (!tnsData[serviceName]) {
+		logger({
+			message: `Connect using first TNS service ${firstTnsServiceName}' from ${path.join(configDir, 'tnsnames.ora')}.`,
+		});
+	}
+
+	const address = tnsService?.data?.description?.address;
+	const service = tnsService?.data?.description?.connect_data?.service_name;
+	const sid = tnsService?.data?.description?.connect_data?.sid;
 
 	logger({ message: 'tnsnames.ora', address, service });
 
@@ -178,6 +188,7 @@ const getSshConnectionString = async (data, sshService, logger) => {
 const connect = async (
 	{
 		walletFile,
+		walletPassword,
 		tempFolder,
 		name,
 		connectionMethod,
@@ -244,11 +255,7 @@ const connect = async (
 	let connectString = '';
 
 	if (['Wallet', 'TNS'].includes(connectionMethod)) {
-		if (proxy) {
-			connectString = getConnectionStringByTnsNames(configDir, serviceName, proxy, logger);
-		} else {
-			connectString = serviceName;
-		}
+		connectString = getConnectionStringByTnsNames(configDir, serviceName, proxy, logger);
 	} else {
 		connectString = getConnectionDescription(
 			{
@@ -303,6 +310,8 @@ const connect = async (
 		password: userPassword,
 		queryRequestTimeout,
 		authRole,
+		walletLocation: configDir,
+		walletPassword,
 	});
 };
 
@@ -327,29 +336,37 @@ const disconnect = async sshService => {
 	});
 };
 
-const authByCredentials = ({ connectString, username, password, queryRequestTimeout, authRole }) => {
+const authByCredentials = ({
+	connectString,
+	username,
+	password,
+	queryRequestTimeout,
+	authRole,
+	walletPassword,
+	walletLocation,
+}) => {
 	return new Promise((resolve, reject) => {
-		oracleDB.getConnection(
-			{
-				username,
-				password,
-				connectString,
-				privilege: authRole === 'default' ? undefined : oracleDB[authRole],
-			},
-			(err, conn) => {
-				if (err) {
-					connection = null;
-					return reject(err);
-				}
-				try {
-					conn.callTimeout = Number(queryRequestTimeout || 0);
-					connection = conn;
-					resolve();
-				} catch (err) {
-					reject(err);
-				}
-			},
-		);
+		const connectionConfig = {
+			username,
+			password,
+			connectString,
+			privilege: authRole === 'default' ? undefined : oracleDB[authRole],
+			walletLocation,
+			walletPassword,
+		};
+		oracleDB.getConnection(connectionConfig, (err, conn) => {
+			if (err) {
+				connection = null;
+				return reject(err);
+			}
+			try {
+				conn.callTimeout = Number(queryRequestTimeout || 0);
+				connection = conn;
+				resolve();
+			} catch (err) {
+				reject(err);
+			}
+		});
 	});
 };
 

--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -68,11 +68,11 @@ const getConnectionStringByTnsNames = (configDir, serviceName, proxy, logger) =>
 	const tnsServicesNames = Object.keys(tnsData);
 
 	if (!tnsData[serviceName] && tnsServicesNames.length === 0) {
-		logger({ message: `Cannot find '${serviceName}' in tnsnames.ora: ${tnsData} and no fallback found` });
+		logger({ message: `Cannot find '${serviceName}' in tnsnames.ora and no fallback found` });
 		return serviceName;
 	}
 
-	const [firstTnsServiceName, ...otherServices] = tnsServicesNames;
+	const [firstTnsServiceName] = tnsServicesNames;
 	const tnsService = tnsData[serviceName] || tnsData[firstTnsServiceName];
 	if (!tnsData[serviceName]) {
 		logger({


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7986" title="HCK-7986" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-7986</a>  Error ORA-12506 with Oracle Autonomous
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

After investigation it appears we need to ask the user for the wallet password (unlike with standalone SQL Developper.  When we don't have the password the oracle server responds with a meaningless error (ACL List, IP not allowed) while the MTLS connection is actually failing.

This PR also loads the first service found in `tnsnames.ora` (usually containing 3 services that only differ by their respective limits in terms of query concurrency).  Like SQL Developper we use the ifrst found in the file.  For old connection, the serviceName that was configured will be used with a fallback to the first TNS service. (see https://docs.oracle.com/en/cloud/paas/autonomous-database/serverless/adbsb/manage-service-concurrency.html#GUID-400B1460-E44D-4BA5-B216-0B185BE55F8E for more details about the autonomous default endpoints)
Note that it's been discussed to c hose the first TNS service instead of asking the user because there isn't currently a way to update/load the `tnsnames.ora` after loading the wallet as the connection screen is static.

See https://hackolade.atlassian.net/browse/HCK-7979
