### PR TITLE
HCK-8126, HCK-8127: RE of sequences and synonyms improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.2.14",
 			"dependencies": {
 				"adm-zip": "0.5.9",
+				"async": "3.2.6",
 				"lodash": "4.17.21",
 				"oracledb": "6.6.0",
 				"perplex": "0.11.0"
@@ -1105,6 +1106,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/async": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
 		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "disabled": false,
     "dependencies": {
         "adm-zip": "0.5.9",
+        "async": "3.2.6",
         "lodash": "4.17.21",
         "oracledb": "6.6.0",
         "perplex": "0.11.0"

--- a/reverse_engineering/helpers/getSchemaSequences.js
+++ b/reverse_engineering/helpers/getSchemaSequences.js
@@ -126,7 +126,10 @@ const getSchemaSequenceDtos = async ({ schema, allDDLs, execute, logger }) => {
 
 		logger.log(
 			'info',
-			{ message: 'Filter sequences finished', usedSequencesCount: usedSequences?.length || 0 },
+			{
+				message: 'Filtering of sequences used in tables and views finished',
+				usedSequencesCount: usedSequences?.length || 0,
+			},
 			'Getting sequences',
 		);
 
@@ -165,7 +168,7 @@ const getSchemaSequenceDtos = async ({ schema, allDDLs, execute, logger }) => {
  */
 const getSchemaSequenceDdl = async ({ schema, namesOfSequences, execute, logger }) => {
 	try {
-		logger.log('info', { message: 'Start getting sequences DDL' }, 'Getting sequences');
+		logger.log('info', { message: 'Start getting sequences DDL' }, 'Getting DDL of sequences');
 
 		const sequenceDdlScriptsPromise = mapLimit(namesOfSequences, 50, async sequenceName => {
 			try {
@@ -176,7 +179,7 @@ const getSchemaSequenceDdl = async ({ schema, namesOfSequences, execute, logger 
 				return [sequenceName, JSON.parse(sequenceDdlScript?.[0]?.[0] || '{}')?.ddl || ''];
 			} catch (error) {
 				const { message, stack, ...err } = error;
-				logger.log('error', { sequenceName, schema, message, stack, err }, 'Getting sequences DDL ERROR');
+				logger.log('error', { sequenceName, schema, message, stack, err }, 'Getting sequence DDL ERROR');
 
 				return [sequenceName, ''];
 			}
@@ -190,7 +193,7 @@ const getSchemaSequenceDdl = async ({ schema, namesOfSequences, execute, logger 
 		logger.log(
 			'info',
 			{ message: 'Finish getting sequences DDL', count: sequenceDdlScripts?.length || 0 },
-			'Getting sequences',
+			'Getting DDL of sequences',
 		);
 
 		if (!sequenceDdlScripts?.length) {
@@ -209,7 +212,7 @@ const getSchemaSequenceDdl = async ({ schema, namesOfSequences, execute, logger 
 		logger.log(
 			'error',
 			{ message: 'Cannot get sequences DDL', error: { message, stack, err } },
-			'Getting sequences',
+			'Getting DDL of sequences',
 		);
 
 		return {};

--- a/reverse_engineering/helpers/getSchemaSequences.js
+++ b/reverse_engineering/helpers/getSchemaSequences.js
@@ -325,7 +325,9 @@ const filterUsedSequences = ({ sequenceDtos, allDDLs }) => {
 	const usedSequences = [];
 
 	for (const sequence of sequenceDtos) {
-		if (allDDLs.includes(sequence.sequenceName.toLowerCase())) {
+		const sequenceRegexp = new RegExp('\\b' + sequence.sequenceName + '\\b', 'i');
+
+		if (sequenceRegexp.test(allDDLs)) {
 			usedSequences.push(sequence);
 		}
 	}

--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -876,7 +876,7 @@ const getSchemaSynonyms = async ({ schema, allDDLs, logger }) => {
 			  LEFT JOIN ALL_OBJECTS
 			    ON ALL_OBJECTS.OWNER = ALL_SYNONYMS.OWNER
 			    AND ALL_OBJECTS.OBJECT_NAME = ALL_SYNONYMS.SYNONYM_NAME
-			  WHERE ORIGIN_CON_ID > 1 AND (ALL_SYNONYMS.OWNER = '${schema}' OR ALL_SYNONYMS.OWNER = 'PUBLIC')
+			  WHERE ORIGIN_CON_ID > 1 AND ALL_SYNONYMS.TABLE_OWNER = '${schema}'
 			`,
 		);
 
@@ -894,7 +894,7 @@ const getSchemaSynonyms = async ({ schema, allDDLs, logger }) => {
 			};
 		});
 
-		return filterUsedSequences({ synonyms, allDDLs });
+		return filterUsedSynonyms({ synonyms, allDDLs });
 	} catch (err) {
 		logger.log(
 			'error',
@@ -912,7 +912,7 @@ const getSchemaSynonyms = async ({ schema, allDDLs, logger }) => {
  * @param {{ synonyms: Array<{ synonymName: string }>, allDDLs: string[] }}
  * @returns {Array}
  */
-const filterUsedSequences = ({ synonyms, allDDLs }) => {
+const filterUsedSynonyms = ({ synonyms, allDDLs }) => {
 	const usedSynonyms = [];
 
 	for (const synonym of synonyms) {

--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -916,7 +916,9 @@ const filterUsedSynonyms = ({ synonyms, allDDLs }) => {
 	const usedSynonyms = [];
 
 	for (const synonym of synonyms) {
-		if (allDDLs.includes(synonym.synonymName.toLowerCase())) {
+		const synonymRegexp = new RegExp('\\b' + synonym.synonymName + '\\b', 'i');
+
+		if (synonymRegexp.test(allDDLs)) {
 			usedSynonyms.push(synonym);
 		}
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8126" title="HCK-8126" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-8126</a>  RE sequences directly used by the selected tables
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* Now we reverse-engineer only those synonyms and sequences that are used in DDL of tables of views
* Removed of `GET_DDL` call for synonyms, replaed it with LEFT JOIN with ALL_OBJECTS to obtain EDITIONABLE
* Improved RE of sequences by calling `GET_DDL` of only used sequences
* Improved logging