### PR TITLE
HCK-8237: field single PK and UK should be mutually exclusive

### DIFF
--- a/adapter/0.2.17.json
+++ b/adapter/0.2.17.json
@@ -1,0 +1,58 @@
+/**
+ * Copyright © 2016-2018 by IntegrIT S.A. dba Hackolade.  All rights reserved.
+ *
+ * The copyright to the computer software herein is the property of IntegrIT S.A.
+ * The software may be used and/or copied only with the written permission of
+ * IntegrIT S.A. or in accordance with the terms and conditions stipulated in
+ * the agreement/contract under which the software has been supplied.
+ *
+ * {
+ * 		"add": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"delete": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"modify": {
+ *	 		"entity": [
+ *	 			{
+ *					"from": { <properties that identify record> },
+ *					"to": { <properties that need to be changed> }
+ *				}
+ *			],
+ *			"container": [],
+ *			"model": [],
+ *			"view": [],
+ *			"field": []
+ * 		},
+ * }
+ */
+{
+	"add": {},
+	"modify": {
+		"field": [
+			{
+				"from": {
+					"primaryKey": true,
+					"unique": true
+				},
+				"to": {
+					"unique": false
+				}
+			}
+		]
+	},
+	"delete": {}
+}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
                 }
             },
             "enableFetchSystemEntitiesCheckbox": true,
-            "discoverRelationships": true
+            "discoverRelationships": true,
+            "enableKeysMultipleAbrr": true
         }
     },
     "description": "Hackolade plugin for Oracle and Autonomous databases",

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1199,6 +1199,13 @@ making sure that you maintain a proper JSON format.
 									]
 								}
 							]
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "unique",
+								"value": true
+							}
 						}
 					]
 				},
@@ -1385,12 +1392,21 @@ making sure that you maintain a proper JSON format.
 							"type": "or",
 							"values": [
 								{
-									"key": "compositePrimaryKey",
-									"value": false
+									"type": "or",
+									"values": [
+										{
+											"key": "primaryKey",
+											"value": false
+										},
+										{
+											"key": "primaryKey",
+											"exist": false
+										}
+									]
 								},
 								{
 									"key": "compositePrimaryKey",
-									"exist": false
+									"value": true
 								}
 							]
 						},
@@ -3014,6 +3030,13 @@ making sure that you maintain a proper JSON format.
 									]
 								}
 							]
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "unique",
+								"value": true
+							}
 						}
 					]
 				},
@@ -3200,12 +3223,21 @@ making sure that you maintain a proper JSON format.
 							"type": "or",
 							"values": [
 								{
-									"key": "compositePrimaryKey",
-									"value": false
+									"type": "or",
+									"values": [
+										{
+											"key": "primaryKey",
+											"value": false
+										},
+										{
+											"key": "primaryKey",
+											"exist": false
+										}
+									]
 								},
 								{
 									"key": "compositePrimaryKey",
-									"exist": false
+									"value": true
 								}
 							]
 						},
@@ -4847,6 +4879,13 @@ making sure that you maintain a proper JSON format.
 									]
 								}
 							]
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "unique",
+								"value": true
+							}
 						}
 					]
 				},
@@ -5033,12 +5072,21 @@ making sure that you maintain a proper JSON format.
 							"type": "or",
 							"values": [
 								{
-									"key": "compositePrimaryKey",
-									"value": false
+									"type": "or",
+									"values": [
+										{
+											"key": "primaryKey",
+											"value": false
+										},
+										{
+											"key": "primaryKey",
+											"exist": false
+										}
+									]
 								},
 								{
 									"key": "compositePrimaryKey",
-									"exist": false
+									"value": true
 								}
 							]
 						},
@@ -8079,6 +8127,13 @@ making sure that you maintain a proper JSON format.
 									]
 								}
 							]
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "unique",
+								"value": true
+							}
 						}
 					]
 				},
@@ -8265,12 +8320,21 @@ making sure that you maintain a proper JSON format.
 							"type": "or",
 							"values": [
 								{
-									"key": "compositePrimaryKey",
-									"value": false
+									"type": "or",
+									"values": [
+										{
+											"key": "primaryKey",
+											"value": false
+										},
+										{
+											"key": "primaryKey",
+											"exist": false
+										}
+									]
 								},
 								{
 									"key": "compositePrimaryKey",
-									"exist": false
+									"value": true
 								}
 							]
 						},
@@ -9303,6 +9367,13 @@ making sure that you maintain a proper JSON format.
 									]
 								}
 							]
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "unique",
+								"value": true
+							}
 						}
 					]
 				},
@@ -9489,12 +9560,21 @@ making sure that you maintain a proper JSON format.
 							"type": "or",
 							"values": [
 								{
-									"key": "compositePrimaryKey",
-									"value": false
+									"type": "or",
+									"values": [
+										{
+											"key": "primaryKey",
+											"value": false
+										},
+										{
+											"key": "primaryKey",
+											"exist": false
+										}
+									]
 								},
 								{
 									"key": "compositePrimaryKey",
-									"exist": false
+									"value": true
 								}
 							]
 						},
@@ -10444,6 +10524,13 @@ making sure that you maintain a proper JSON format.
 									]
 								}
 							]
+						},
+						{
+							"type": "not",
+							"values": {
+								"key": "unique",
+								"value": true
+							}
 						}
 					]
 				},
@@ -10630,12 +10717,21 @@ making sure that you maintain a proper JSON format.
 							"type": "or",
 							"values": [
 								{
-									"key": "compositePrimaryKey",
-									"value": false
+									"type": "or",
+									"values": [
+										{
+											"key": "primaryKey",
+											"value": false
+										},
+										{
+											"key": "primaryKey",
+											"exist": false
+										}
+									]
 								},
 								{
 									"key": "compositePrimaryKey",
-									"exist": false
+									"value": true
 								}
 							]
 						},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8237" title="HCK-8237" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-8237</a>  Single PK should not be also declared as single UK (mutually exclusive) - config only?
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

In this PR:
- I added hiding unique field property if it's already a single primary and vice versa.
- added an adapter to remove a single "unique" property in case a field is a single PK and a single UK simultaneously. In another case, both properties would be hidden.
- allowed for a field to be checked as unique in case it is already a part of a composite primary key.