### PR TITLE
HCK-9144: Oracle table can have only one identity number column

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -2707,7 +2707,12 @@ making sure that you maintain a proper JSON format.
 					{
 						"propertyName": "As identity",
 						"propertyKeyword": "asIdentity",
-						"propertyType": "checkbox"
+						"propertyType": "checkbox",
+						"disabledOnCondition": {
+							"level": "siblings",
+							"key": "generatedDefaultValue.asIdentity",
+							"value": true
+						}
 					},
 					{
 						"propertyName": "Expression",
@@ -2755,7 +2760,12 @@ making sure that you maintain a proper JSON format.
 					{
 						"propertyName": "As identity",
 						"propertyKeyword": "asIdentity",
-						"propertyType": "checkbox"
+						"propertyType": "checkbox",
+						"disabledOnCondition": {
+							"level": "siblings",
+							"key": "generatedDefaultValue.asIdentity",
+							"value": true
+						}
 					},
 					{
 						"propertyName": "Type",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9144" title="HCK-9144" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9144</a>  RE. 'ALWAYS AS' cases DDL validation absence
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Disable `As identity` if there is another identity column in the table