### PR TITLE
HCK-9173: comment out inactive schema statement in script

### DIFF
--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -144,10 +144,11 @@ module.exports = (baseProvider, options, app) => {
 				dbVersion,
 				synonyms: data.synonyms,
 				sequences: data.sequences,
+				isActivated: containerData.isActivated,
 			};
 		},
 
-		createSchema({ schemaName, ifNotExist, dbVersion, sequences }) {
+		createSchema({ schemaName, ifNotExist, dbVersion, sequences, isActivated }) {
 			const emptyLineSeparator = '\n\n';
 			const statementTerminator = ';';
 
@@ -165,18 +166,19 @@ module.exports = (baseProvider, options, app) => {
 			});
 
 			if (!usingTryCatchWrapper) {
-				return (
+				return commentIfDeactivated(
 					schemaStatement +
-					statementTerminator +
-					emptyLineSeparator +
-					alterSessionStatement +
-					schemaSequencesStatement
+						statementTerminator +
+						emptyLineSeparator +
+						alterSessionStatement +
+						schemaSequencesStatement,
+					{ isActivated },
 				);
 			}
 
 			const wrappedSchemaStatement = wrapIfNotExists(schemaStatement, ifNotExist, 1920);
 
-			return wrappedSchemaStatement + schemaSequencesStatement;
+			return commentIfDeactivated(wrappedSchemaStatement + schemaSequencesStatement, { isActivated });
 		},
 
 		hydrateColumn({ columnDefinition, jsonSchema, schemaData, definitionJsonSchema = {} }) {

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -148,7 +148,7 @@ module.exports = (baseProvider, options, app) => {
 			};
 		},
 
-		createSchema({ schemaName, ifNotExist, dbVersion, sequences, isActivated }) {
+		createSchema({ schemaName, ifNotExist, dbVersion, sequences, isActivated = true }) {
 			const emptyLineSeparator = '\n\n';
 			const statementTerminator = ';';
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
             },
             "enableFetchSystemEntitiesCheckbox": true,
             "discoverRelationships": true,
-            "enableKeysMultipleAbrr": true
+            "enableKeysMultipleAbrr": true,
+			"FEScriptCommentsSupported": true
         }
     },
     "description": "Hackolade plugin for Oracle and Autonomous databases",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9173" title="HCK-9173" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9173</a>  Statements are still incorrectly present in DDL/Script tab after 'isActivated' is disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

You have no Jira task for this PR? Describe your changes here...

...

## Technical details

You feel the need to provide technical explanations? You can do it here...

...