### PR TITLE
HCK-9323: add dependency for storage logging option

### DIFF
--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -199,7 +199,20 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Logging",
 						"propertyKeyword": "logging",
 						"propertyTooltip": "Specify whether the creation of the table and of any indexes required because of constraints, partition, or LOB storage characteristics will be logged in the redo log file (LOGGING) or not (NOLOGGING).",
-						"propertyType": "checkbox"
+						"propertyType": "checkbox",
+						"dependency": {
+							"type": "or",
+							"values": [
+								{
+									"key": "organization",
+									"value": "heap"
+								},
+								{
+									"key": "organization",
+									"value": "index"
+								}
+							]
+						}
 					},
 					{
 						"propertyName": "Row archival",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9323" title="HCK-9323" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9323</a>  [Oracle] Invalid ability to edit Logging property for EXTERNAL table storage type
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
