### PR TITLE
HCK-9505: ability to uncheck AS IDENTITY when it should be disabled

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -2772,24 +2772,7 @@ making sure that you maintain a proper JSON format.
 					{
 						"propertyName": "As identity",
 						"propertyKeyword": "asIdentity",
-						"propertyType": "checkbox",
-						"disabledOnCondition": {
-							"type": "and",
-							"values": [
-								{
-									"level": "siblings",
-									"key": "generatedDefaultValue.asIdentity",
-									"value": true
-								},
-								{
-									"type": "not",
-									"values": {
-										"key": "generatedDefaultValue.asIdentity",
-										"value": true
-									}
-								}
-							]
-						}
+						"propertyType": "checkbox"
 					},
 					{
 						"propertyName": "Type",

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -2712,6 +2712,18 @@ making sure that you maintain a proper JSON format.
 							"level": "siblings",
 							"key": "generatedDefaultValue.asIdentity",
 							"value": true
+						},
+						"propertyTooltip": {
+							"disabled": [
+								{
+									"tooltip": "Another column has already been selected as identity. You must unselect it prior to selecting this column.",
+									"dependency": {
+										"level": "siblings",
+										"key": "generatedDefaultValue.asIdentity",
+										"value": true
+									}
+								}
+							]
 						}
 					},
 					{
@@ -2762,9 +2774,18 @@ making sure that you maintain a proper JSON format.
 						"propertyKeyword": "asIdentity",
 						"propertyType": "checkbox",
 						"disabledOnCondition": {
-							"level": "siblings",
-							"key": "generatedDefaultValue.asIdentity",
-							"value": true
+							"type": "and",
+							"values": [
+								{
+									"level": "siblings",
+									"key": "generatedDefaultValue.asIdentity",
+									"value": true
+								},
+								{
+									"key": "generatedDefaultValue.asIdentity",
+									"value": false
+								}
+							]
 						}
 					},
 					{

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -2782,8 +2782,11 @@ making sure that you maintain a proper JSON format.
 									"value": true
 								},
 								{
-									"key": "generatedDefaultValue.asIdentity",
-									"value": false
+									"type": "not",
+									"values": {
+										"key": "generatedDefaultValue.asIdentity",
+										"value": true
+									}
 								}
 							]
 						}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9505" title="HCK-9505" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9505</a>  Oracle: Add an ability to uncheck the "as identity" checkbox property on collections with multiple "as identity" column
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Only one column can have the "AS IDENTITY" checkbox checked in a collection, other are disabled in this case. If somehow there are more of them enabled, then enable the checked checkboxes so users can uncheck the ones that are not needed.

Add a tooltip to disabled checkboxes.