### PR TITLE
HCK-9530: column DDL statement is not valid when "as identity" is selected for a column

### DIFF
--- a/forward_engineering/ddlProvider/ddlHelpers/columnDefinitionHelpers/getColumnDefault.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/columnDefinitionHelpers/getColumnDefault.js
@@ -58,7 +58,7 @@ const getGeneratedClause = ({ generatedType, generatedOnNull }) => {
  * @param {{ identityStart?: number; identityIncrement?: number; numberToCache?: number; }}
  * @returns {string}
  */
-const getIdentityOptions = ({ identityStart, identityIncrement, numberToCache }) => {
+const getIdentityOptions = ({ identityStart, identityIncrement, numberToCache } = {}) => {
 	const startWith = isNumber(identityStart) ? ` START WITH ${identityStart}` : '';
 	const incrementBy = isNumber(identityIncrement) ? ` INCREMENT BY ${identityIncrement}` : '';
 	const cache = isNumber(numberToCache) ? ` CACHE ${numberToCache}` : ' NOCACHE';
@@ -75,7 +75,7 @@ const getColumnDefault = ({ type, default: defaultValue, defaultOnNull, generate
 	const generatedClause = getGeneratedClause({ generatedType, generatedOnNull });
 	const expressionValue = trim(expression);
 
-	if (asIdentity && canHaveIdentity({ type }) && !isEmpty(identity)) {
+	if (asIdentity && canHaveIdentity({ type })) {
 		const identityOptions = getIdentityOptions(identity);
 
 		return `${generatedClause} AS IDENTITY (${identityOptions})`;

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -2667,47 +2667,14 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "block",
 				"structure": [
 					{
-						"propertyName": "Expression",
-						"propertyKeyword": "expression",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
-					}
-				],
-				"dependency": {
-					"type": "not",
-					"values": [
-						{
-							"key": "mode",
-							"value": "number"
-						},
-						{
-							"key": "generatedDefaultValue.asIdentity",
-							"value": true
-						},
-						{
-							"level": "root",
-							"key": "viewOn",
-							"exist": true
-						},
-						{
-							"level": "root",
-							"key": "duality",
-							"value": true
-						}
-					]
-				}
-			},
-			{
-				"propertyName": "Generated as",
-				"propertyTooltip": "",
-				"propertyKeyword": "generatedDefaultValue",
-				"propertyType": "block",
-				"structure": [
-					{
 						"propertyName": "As identity",
 						"propertyKeyword": "asIdentity",
 						"propertyType": "checkbox",
+						"dependency": {
+							"level": "objectRoot",
+							"key": "mode",
+							"value": "number"
+						},
 						"disabledOnCondition": {
 							"level": "siblings",
 							"key": "generatedDefaultValue.asIdentity",
@@ -2731,55 +2698,25 @@ making sure that you maintain a proper JSON format.
 						"propertyKeyword": "expression",
 						"propertyType": "details",
 						"template": "textarea",
-						"markdown": false
-					}
-				],
-				"dependency": {
-					"type": "and",
-					"values": [
-						{
-							"key": "mode",
-							"value": "number"
-						},
-						{
+						"markdown": false,
+						"dependency": {
 							"type": "not",
-							"values": [
-								{
-									"key": "generatedDefaultValue.asIdentity",
-									"value": true
-								},
-								{
-									"level": "root",
-									"key": "viewOn",
-									"exist": true
-								},
-								{
-									"level": "root",
-									"key": "duality",
-									"value": true
-								}
-							]
+							"values": {
+								"key": "asIdentity",
+								"value": true
+							}
 						}
-					]
-				}
-			},
-			{
-				"propertyName": "Generated as",
-				"propertyTooltip": "",
-				"propertyKeyword": "generatedDefaultValue",
-				"propertyType": "block",
-				"structure": [
-					{
-						"propertyName": "As identity",
-						"propertyKeyword": "asIdentity",
-						"propertyType": "checkbox"
 					},
 					{
 						"propertyName": "Type",
 						"propertyKeyword": "generatedType",
 						"propertyType": "select",
 						"options": ["ALWAYS", "BY DEFAULT"],
-						"defaultValue": "ALWAYS"
+						"defaultValue": "ALWAYS",
+						"dependency": {
+							"key": "asIdentity",
+							"value": true
+						}
 					},
 					{
 						"propertyName": "On null",
@@ -2796,27 +2733,10 @@ making sure that you maintain a proper JSON format.
 						"propertyType": "block",
 						"propertyKeyword": "identity",
 						"propertyTooltip": "Creates an identity column in a table",
-						"structure": [],
 						"dependency": {
-							"type": "or",
-							"values": [
-								{
-									"key": "generatedType",
-									"exist": false
-								},
-								{
-									"key": "generatedType",
-									"value": ""
-								}
-							]
-						}
-					},
-
-					{
-						"propertyName": "Identity",
-						"propertyType": "block",
-						"propertyKeyword": "identity",
-						"propertyTooltip": "Creates an identity column in a table",
+							"key": "asIdentity",
+							"value": true
+						},
 						"structure": [
 							{
 								"propertyName": "Start",
@@ -2845,50 +2765,21 @@ making sure that you maintain a proper JSON format.
 								"minValue": 1,
 								"step": 1
 							}
-						],
-						"dependency": {
-							"type": "not",
-							"values": {
-								"type": "or",
-								"values": [
-									{
-										"key": "generatedType",
-										"exist": false
-									},
-									{
-										"key": "generatedType",
-										"value": ""
-									}
-								]
-							}
-						}
+						]
 					}
 				],
 				"dependency": {
-					"type": "and",
+					"type": "not",
 					"values": [
 						{
-							"key": "mode",
-							"value": "number"
+							"level": "root",
+							"key": "viewOn",
+							"exist": true
 						},
 						{
-							"key": "generatedDefaultValue.asIdentity",
+							"level": "root",
+							"key": "duality",
 							"value": true
-						},
-						{
-							"type": "not",
-							"values": [
-								{
-									"level": "root",
-									"key": "viewOn",
-									"exist": true
-								},
-								{
-									"level": "root",
-									"key": "duality",
-									"value": true
-								}
-							]
 						}
 					]
 				}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9530" title="HCK-9530" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9530</a>  [Oracle][Identity][DDL] DDL is not generated for number column marked as Identity until 'Identity' section is expanded in PP
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

The "Identity" object shouldn't be required to generate DDL for the "as identity" column. The "as identity" property equaling `true` should be enough to generate DDL. The default value for the "Type" property will be handled separately.

"Generated as" configs are merged into a single structure for simplicity.