### PR TITLE
HCK-9966: number precision

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -2461,7 +2461,7 @@ making sure that you maintain a proper JSON format.
 				"valueType": "number",
 				"propertyTooltip": "Setting for Precision must be between 1 and 39",
 				"minValue": 1,
-				"maxValue": 39,
+				"maxValue": 38,
 				"typeDecorator": true,
 				"dependency": {
 					"type": "and",

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -2459,7 +2459,7 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "precision",
 				"propertyType": "numeric",
 				"valueType": "number",
-				"propertyTooltip": "Setting for Precision must be between 1 and 39",
+				"propertyTooltip": "Setting for Precision must be between 1 and 38",
 				"minValue": 1,
 				"maxValue": 38,
 				"typeDecorator": true,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9966" title="HCK-9966" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9966</a>  Oracle: change config: max precision for number = 38 (not 39)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* following the spec for NUMBER precision