### PR TITLE
HCK-10442: add support for hasMaxLength property on Polyglot conversion/derivement

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -77,6 +77,33 @@
 					"subtype": "vector<float32>"
 				}
 			},
+			{
+				"from": {
+					"type": "varchar",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 32767
+				}
+			},
+			{
+				"from": {
+					"type": "nvarchar",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 32767
+				}
+			},
+			{
+				"from": {
+					"type": "binary",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 8000
+				}
+			},
 			[
 				"renameBlockItemProperties",
 				{

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -66,6 +66,30 @@
 					"mode": "integer"
 				}
 			},
+			{
+				"from": {
+					"length": 32767
+				},
+				"to": {
+					"hasMaxLength": true
+				}
+			},
+			{
+				"from": {
+					"length": 32767
+				},
+				"to": {
+					"hasMaxLength": true
+				}
+			},
+			{
+				"from": {
+					"length": 8000
+				},
+				"to": {
+					"hasMaxLength": true
+				}
+			},
 			[
 				"movePropertyByPath",
 				{

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -68,6 +68,7 @@
 			},
 			{
 				"from": {
+					"mode": "varchar2",
 					"length": 32767
 				},
 				"to": {
@@ -76,6 +77,7 @@
 			},
 			{
 				"from": {
+					"mode": "nvarchar2",
 					"length": 32767
 				},
 				"to": {
@@ -84,6 +86,7 @@
 			},
 			{
 				"from": {
+					"type": "binary",
 					"length": 8000
 				},
 				"to": {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10442" title="HCK-10442" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10442</a>  Implement max length mapping for RDBMS-like database targets (cross-target conversion)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added adapter for conversion/derivement of hasMaxLength property