### PR TITLE
HCK-10530: updated adapter config to handle haxMaxLength for char and nchar

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -88,11 +88,31 @@
 			},
 			{
 				"from": {
+					"type": "varchar",
+					"mode": "char",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 2000
+				}
+			},
+			{
+				"from": {
 					"type": "nvarchar",
 					"hasMaxLength": true
 				},
 				"to": {
 					"length": 32767
+				}
+			},
+			{
+				"from": {
+					"type": "nvarchar",
+					"mode": "nchar",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 2000
 				}
 			},
 			{

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -86,6 +86,24 @@
 			},
 			{
 				"from": {
+					"mode": "char",
+					"length": 2000
+				},
+				"to": {
+					"hasMaxLength": true
+				}
+			},
+			{
+				"from": {
+					"mode": "nchar",
+					"length": 2000
+				},
+				"to": {
+					"hasMaxLength": true
+				}
+			},
+			{
+				"from": {
 					"type": "binary",
 					"length": 8000
 				},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10530" title="HCK-10530" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10530</a>  [Oracle] char/nchar datatypes with max length incorrect derived/converted from/to Poly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Updated adapter config to handle haxMaxLength for char and nchar