### PR TITLE
HCK-12532: fix "create index" duplicates

### DIFF
--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -128,8 +128,8 @@ const getAlterCollectionsScriptDtos = ({
 	return [
 		...createCollectionsScriptDtos,
 		...deleteCollectionScriptDtos,
-		...modifyCollectionScriptDtos,
 		...addColumnScriptDtos,
+		...modifyCollectionScriptDtos,
 		...deleteColumnScriptDtos,
 		...modifyColumnScriptDtos,
 	].filter(Boolean);

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -140,8 +140,7 @@ const getAddColumnScriptDtos =
 			.map(script => AlterScriptDto.getInstance([script], true, false))
 			.filter(Boolean);
 
-		const indexesOnNewlyCreatedColumns = getNewlyCreatedIndexesScripts({ ddlProvider, collection });
-		return scripts.concat(indexesOnNewlyCreatedColumns).filter(Boolean);
+		return scripts.filter(Boolean);
 	};
 
 /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12532" title="HCK-12532" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12532</a>  [DeltaModel]: Double "create index" statement
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Keys handled by collection modifications ([it was fixed in the studio](https://github.com/hackolade/studio/pull/3784)). But statements are duplicated because they are also handled by the added columns. Keep statements handled only by collection modifications. The added columns should generate SQL only to add the columns.

Also, create columns before modifying collection indexes.