### PR TITLE
HCK-12606: fix default value for column comments option

### DIFF
--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -423,7 +423,7 @@
 					"disabledLabel": ""
 				},
 				"separate": {
-					"default": false,
+					"default": true,
 					"disabled": false,
 					"disabledLabel": ""
 				},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12606" title="HCK-12606" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12606</a>  [Script generation options][Oracle] Missing default setting state for Column comments
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
