### PR TITLE
HCK-12615: fix getting full table name for alter check constraint

### DIFF
--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
@@ -1,7 +1,12 @@
 const _ = require('lodash');
 const { AlterCollectionDto } = require('../../types/AlterCollectionDto');
 const { AlterScriptDto } = require('../../types/AlterScriptDto');
-const { wrapInQuotes, getNamePrefixedWithSchemaNameForScriptFormat } = require('../../../utils/general');
+const {
+	wrapInQuotes,
+	getNamePrefixedWithSchemaNameForScriptFormat,
+	getSchemaOfAlterCollection,
+	getFullCollectionName,
+} = require('../../../utils/general');
 const { assignTemplates } = require('../../../utils/assignTemplates');
 const templates = require('../../../ddlProvider/templates');
 
@@ -141,9 +146,8 @@ const getUpdateCheckConstraintScriptDtos = (constraintHistory, fullTableName) =>
 const getModifyCheckConstraintScriptDtos =
 	({ scriptFormat }) =>
 	collection => {
-		const tableName = collection.compMod?.collectionName?.new;
-		const schemaName = collection.compMod?.keyspaceName;
-		const fullName = getNamePrefixedWithSchemaNameForScriptFormat(scriptFormat)(tableName, schemaName);
+		const collectionSchema = getSchemaOfAlterCollection(collection);
+		const fullName = getFullCollectionName(scriptFormat)(collectionSchema);
 
 		const constraintHistory = mapCheckConstraintNamesToChangeHistory(collection);
 

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
@@ -1,12 +1,7 @@
 const _ = require('lodash');
 const { AlterCollectionDto } = require('../../types/AlterCollectionDto');
 const { AlterScriptDto } = require('../../types/AlterScriptDto');
-const {
-	wrapInQuotes,
-	getNamePrefixedWithSchemaNameForScriptFormat,
-	getSchemaOfAlterCollection,
-	getFullCollectionName,
-} = require('../../../utils/general');
+const { wrapInQuotes, getSchemaOfAlterCollection, getFullCollectionName } = require('../../../utils/general');
 const { assignTemplates } = require('../../../utils/assignTemplates');
 const templates = require('../../../ddlProvider/templates');
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12615" title="HCK-12615" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12615</a>  [FE to DDL][Script generation options][Oracle] Invalid table name is generated for Check constraint and In separate statement strategy if Table has only TECH name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
