### PR TITLE
HCK-12973: try to query DBA_* views in RE

### DIFF
--- a/reverse_engineering/helpers/getSchemaSequences.js
+++ b/reverse_engineering/helpers/getSchemaSequences.js
@@ -75,7 +75,9 @@ const SEQUENCE_OPTION_MAP = {
 
 /**
  * Generates a SQL query to retrieve sequence information using ALL_* tables.
- * This approach works for most Oracle users who have standard access privileges.
+ * This approach is used as a fallback for users who don't have access to DBA_* tables.
+ * Works for most Oracle users who have standard access privileges.
+ * The query structure is identical to the DBA_* version but uses ALL_* views.
  *
  * @param {{ schema: string }} params
  * @param {string} params.schema - The Oracle schema name to query sequences from
@@ -113,8 +115,8 @@ const getSequencesQueryUsingAllTables = ({ schema }) => {
 
 /**
  * Generates a SQL query to retrieve sequence information using DBA_* tables.
- * This approach is used as a fallback for users with SELECT_CATALOG_ROLE who have
- * access to DBA_* tables but may not have access to ALL_* tables.
+ * This is the preferred approach as it provides richer results and access to all sequences
+ * in the database. Requires SELECT_CATALOG_ROLE or equivalent privileges.
  * The query structure is identical to the ALL_* version but uses DBA_* views.
  *
  * @param {{ schema: string }} params
@@ -155,8 +157,8 @@ const getSequencesQueryUsingDbaTables = ({ schema }) => {
  * Retrieves sequence data from an Oracle schema with automatic fallback capability.
  *
  * This function implements a two-tier approach:
- * 1. First attempts to use ALL_* tables (standard approach for most users)
- * 2. Falls back to DBA_* tables if ALL_* fails or returns empty results (for SELECT_CATALOG_ROLE users)
+ * 1. First attempts to use DBA_* tables (for users with SELECT_CATALOG_ROLE - provides richer results)
+ * 2. Falls back to ALL_* tables if DBA_* fails or returns empty results (standard approach for most users)
  *
  * The function filters out sequences associated with identity columns and only returns
  * sequences that are actually used in the schema (referenced in DDL scripts).
@@ -173,46 +175,41 @@ const getSchemaSequenceDtos = async ({ schema, allDDLs, execute, logger }) => {
 		logger.log('info', { message: 'Start getting sequences' }, 'Getting sequences');
 
 		let rawSequenceDtos;
-		let queryApproach = 'ALL_* tables';
-		let shouldTryDbaFallback = false;
+		let queryApproach = 'DBA_* tables';
+		let shouldTryAllFallback = false;
 
 		try {
-			const allTablesQuery = getSequencesQueryUsingAllTables({ schema });
-			const allTablesResult = await execute(allTablesQuery);
-			rawSequenceDtos = allTablesResult.map(([rawSequence]) => JSON.parse(rawSequence));
+			const dbaTablesQuery = getSequencesQueryUsingDbaTables({ schema });
+			const dbaTablesResult = await execute(dbaTablesQuery);
+			rawSequenceDtos = dbaTablesResult.map(([rawSequence]) => JSON.parse(rawSequence));
 
 			if (!rawSequenceDtos || rawSequenceDtos.length === 0) {
-				shouldTryDbaFallback = true;
+				shouldTryAllFallback = true;
 			}
-		} catch (allTablesError) {
+		} catch (dbaTablesError) {
 			logger.log(
 				'info',
 				{
-					message:
-						'ALL_* tables approach failed with exception, trying DBA_* tables for SELECT_CATALOG_ROLE users',
-					error: allTablesError.message,
+					message: 'DBA_* tables approach failed with exception, trying ALL_* tables fallback',
+					error: dbaTablesError.message,
 				},
 				'Getting sequences',
 			);
-			shouldTryDbaFallback = true;
+			shouldTryAllFallback = true;
 		}
 
-		if (shouldTryDbaFallback) {
-			logger.log(
-				'info',
-				{ message: 'Trying DBA_* tables approach for SELECT_CATALOG_ROLE users' },
-				'Getting sequences',
-			);
-			queryApproach = 'DBA_* tables';
+		if (shouldTryAllFallback) {
+			logger.log('info', { message: 'Trying ALL_* tables approach as fallback' }, 'Getting sequences');
+			queryApproach = 'ALL_* tables';
 
 			try {
-				const dbaTablesQuery = getSequencesQueryUsingDbaTables({ schema });
-				const dbaTablesResult = await execute(dbaTablesQuery);
-				rawSequenceDtos = dbaTablesResult.map(([rawSequence]) => JSON.parse(rawSequence));
-			} catch (dbaTablesError) {
+				const allTablesQuery = getSequencesQueryUsingAllTables({ schema });
+				const allTablesResult = await execute(allTablesQuery);
+				rawSequenceDtos = allTablesResult.map(([rawSequence]) => JSON.parse(rawSequence));
+			} catch (allTablesError) {
 				logger.log(
 					'info',
-					{ message: 'DBA_* tables approach also failed, using empty result' },
+					{ message: 'ALL_* tables approach also failed, using empty result', error: allTablesError.message },
 					'Getting sequences',
 				);
 				rawSequenceDtos = [];

--- a/reverse_engineering/helpers/getSchemaSequences.js
+++ b/reverse_engineering/helpers/getSchemaSequences.js
@@ -74,47 +74,158 @@ const SEQUENCE_OPTION_MAP = {
 };
 
 /**
- * @param {{ schema: string, execute: Execute, logger: object, allDDLs: string }}
- * @returns {Promise<SequenceDto[]>}
+ * Generates a SQL query to retrieve sequence information using ALL_* tables.
+ * This approach works for most Oracle users who have standard access privileges.
+ *
+ * @param {{ schema: string }} params
+ * @param {string} params.schema - The Oracle schema name to query sequences from
+ * @returns {string} SQL query string for retrieving sequences from ALL_* tables
+ */
+const getSequencesQueryUsingAllTables = ({ schema }) => {
+	return `
+		SELECT JSON_OBJECT(
+		    'sharing'      VALUE ALL_OBJECTS.SHARING,
+		    'sequenceName' VALUE ALL_SEQUENCES.SEQUENCE_NAME,
+		    'minValue'     VALUE ALL_SEQUENCES.MIN_VALUE,
+		    'maxValue'     VALUE ALL_SEQUENCES.MAX_VALUE,
+		    'increment'    VALUE ALL_SEQUENCES.INCREMENT_BY,
+		    'cycle'        VALUE ALL_SEQUENCES.CYCLE_FLAG,
+		    'order'        VALUE ALL_SEQUENCES.ORDER_FLAG,
+		    'cacheValue'   VALUE ALL_SEQUENCES.CACHE_SIZE,
+		    'scale'        VALUE ALL_SEQUENCES.SCALE_FLAG,
+		    'extend'       VALUE ALL_SEQUENCES.EXTEND_FLAG,
+		    'shard'        VALUE ALL_SEQUENCES.SHARDED_FLAG,
+		    'type'         VALUE ALL_SEQUENCES.SESSION_FLAG,
+		    'keep'         VALUE ALL_SEQUENCES.KEEP_VALUE
+		)
+		FROM ALL_OBJECTS
+		LEFT JOIN ALL_SEQUENCES
+		  ON ALL_SEQUENCES.SEQUENCE_OWNER = ALL_OBJECTS.OWNER
+		  AND ALL_SEQUENCES.SEQUENCE_NAME = ALL_OBJECTS.OBJECT_NAME
+		LEFT JOIN ALL_TAB_IDENTITY_COLS
+		  ON ALL_TAB_IDENTITY_COLS.SEQUENCE_NAME = ALL_SEQUENCES.SEQUENCE_NAME
+		  AND ALL_TAB_IDENTITY_COLS.OWNER = ALL_OBJECTS.OWNER
+		-- take only sequences that are not associated with identity columns
+		WHERE ALL_OBJECTS.OBJECT_TYPE = 'SEQUENCE' AND ALL_TAB_IDENTITY_COLS.COLUMN_NAME IS NULL
+		AND ALL_OBJECTS.OWNER = '${schema}'
+	`;
+};
+
+/**
+ * Generates a SQL query to retrieve sequence information using DBA_* tables.
+ * This approach is used as a fallback for users with SELECT_CATALOG_ROLE who have
+ * access to DBA_* tables but may not have access to ALL_* tables.
+ * The query structure is identical to the ALL_* version but uses DBA_* views.
+ *
+ * @param {{ schema: string }} params
+ * @param {string} params.schema - The Oracle schema name to query sequences from
+ * @returns {string} SQL query string for retrieving sequences from DBA_* tables
+ */
+const getSequencesQueryUsingDbaTables = ({ schema }) => {
+	return `
+		SELECT JSON_OBJECT(
+		    'sharing'      VALUE DBA_OBJECTS.SHARING,
+		    'sequenceName' VALUE DBA_SEQUENCES.SEQUENCE_NAME,
+		    'minValue'     VALUE DBA_SEQUENCES.MIN_VALUE,
+		    'maxValue'     VALUE DBA_SEQUENCES.MAX_VALUE,
+		    'increment'    VALUE DBA_SEQUENCES.INCREMENT_BY,
+		    'cycle'        VALUE DBA_SEQUENCES.CYCLE_FLAG,
+		    'order'        VALUE DBA_SEQUENCES.ORDER_FLAG,
+		    'cacheValue'   VALUE DBA_SEQUENCES.CACHE_SIZE,
+		    'scale'        VALUE DBA_SEQUENCES.SCALE_FLAG,
+		    'extend'       VALUE DBA_SEQUENCES.EXTEND_FLAG,
+		    'shard'        VALUE DBA_SEQUENCES.SHARDED_FLAG,
+		    'type'         VALUE DBA_SEQUENCES.SESSION_FLAG,
+		    'keep'         VALUE DBA_SEQUENCES.KEEP_VALUE
+		)
+		FROM DBA_OBJECTS
+		LEFT JOIN DBA_SEQUENCES
+		  ON DBA_SEQUENCES.SEQUENCE_OWNER = DBA_OBJECTS.OWNER
+		  AND DBA_SEQUENCES.SEQUENCE_NAME = DBA_OBJECTS.OBJECT_NAME
+		LEFT JOIN DBA_TAB_IDENTITY_COLS
+		  ON DBA_TAB_IDENTITY_COLS.SEQUENCE_NAME = DBA_SEQUENCES.SEQUENCE_NAME
+		  AND DBA_TAB_IDENTITY_COLS.OWNER = DBA_OBJECTS.OWNER
+		-- take only sequences that are not associated with identity columns
+		WHERE DBA_OBJECTS.OBJECT_TYPE = 'SEQUENCE' AND DBA_TAB_IDENTITY_COLS.COLUMN_NAME IS NULL
+		AND DBA_OBJECTS.OWNER = '${schema}'
+	`;
+};
+
+/**
+ * Retrieves sequence data from an Oracle schema with automatic fallback capability.
+ *
+ * This function implements a two-tier approach:
+ * 1. First attempts to use ALL_* tables (standard approach for most users)
+ * 2. Falls back to DBA_* tables if ALL_* fails or returns empty results (for SELECT_CATALOG_ROLE users)
+ *
+ * The function filters out sequences associated with identity columns and only returns
+ * sequences that are actually used in the schema (referenced in DDL scripts).
+ *
+ * @param {{ schema: string, execute: Execute, logger: object, allDDLs: string }} params
+ * @param {string} params.schema - The Oracle schema name to retrieve sequences from
+ * @param {Execute} params.execute - Database execution function for running SQL queries
+ * @param {object} params.logger - Logger instance for tracking progress and errors
+ * @param {string} params.allDDLs - All DDL scripts from the schema used to filter sequences that are actually used
+ * @returns {Promise<SequenceDto[]>} Promise that resolves to an array of sequence DTOs with metadata and DDL scripts
  */
 const getSchemaSequenceDtos = async ({ schema, allDDLs, execute, logger }) => {
 	try {
 		logger.log('info', { message: 'Start getting sequences' }, 'Getting sequences');
-		const rawSequenceDtos = (
-			await execute(
-				`
-				SELECT JSON_OBJECT(
-				    'sharing'      VALUE ALL_OBJECTS.SHARING,
-				    'sequenceName' VALUE ALL_SEQUENCES.SEQUENCE_NAME,
-				    'minValue'     VALUE ALL_SEQUENCES.MIN_VALUE,
-				    'maxValue'     VALUE ALL_SEQUENCES.MAX_VALUE,
-				    'increment'    VALUE ALL_SEQUENCES.INCREMENT_BY,
-				    'cycle'        VALUE ALL_SEQUENCES.CYCLE_FLAG,
-				    'order'        VALUE ALL_SEQUENCES.ORDER_FLAG,
-				    'cacheValue'   VALUE ALL_SEQUENCES.CACHE_SIZE,
-				    'scale'        VALUE ALL_SEQUENCES.SCALE_FLAG,
-				    'extend'       VALUE ALL_SEQUENCES.EXTEND_FLAG,
-				    'shard'        VALUE ALL_SEQUENCES.SHARDED_FLAG,
-				    'type'         VALUE ALL_SEQUENCES.SESSION_FLAG,
-				    'keep'         VALUE ALL_SEQUENCES.KEEP_VALUE
-				)
-				FROM ALL_OBJECTS
-				LEFT JOIN ALL_SEQUENCES
-				  ON ALL_SEQUENCES.SEQUENCE_OWNER = ALL_OBJECTS.OWNER
-				  AND ALL_SEQUENCES.SEQUENCE_NAME = ALL_OBJECTS.OBJECT_NAME
-				LEFT JOIN ALL_TAB_IDENTITY_COLS
-				  ON ALL_TAB_IDENTITY_COLS.SEQUENCE_NAME = ALL_SEQUENCES.SEQUENCE_NAME
-				  AND ALL_TAB_IDENTITY_COLS.OWNER = ALL_OBJECTS.OWNER
-				-- take only sequences that are not associated with identity columns
-				WHERE ALL_OBJECTS.OBJECT_TYPE = 'SEQUENCE' AND ALL_TAB_IDENTITY_COLS.COLUMN_NAME IS NULL
-				AND ALL_OBJECTS.OWNER = '${schema}'
-     		 `,
-			)
-		).map(([rawSequence]) => JSON.parse(rawSequence));
+
+		let rawSequenceDtos;
+		let queryApproach = 'ALL_* tables';
+		let shouldTryDbaFallback = false;
+
+		try {
+			const allTablesQuery = getSequencesQueryUsingAllTables({ schema });
+			const allTablesResult = await execute(allTablesQuery);
+			rawSequenceDtos = allTablesResult.map(([rawSequence]) => JSON.parse(rawSequence));
+
+			if (!rawSequenceDtos || rawSequenceDtos.length === 0) {
+				shouldTryDbaFallback = true;
+			}
+		} catch (allTablesError) {
+			logger.log(
+				'info',
+				{
+					message:
+						'ALL_* tables approach failed with exception, trying DBA_* tables for SELECT_CATALOG_ROLE users',
+					error: allTablesError.message,
+				},
+				'Getting sequences',
+			);
+			shouldTryDbaFallback = true;
+		}
+
+		if (shouldTryDbaFallback) {
+			logger.log(
+				'info',
+				{ message: 'Trying DBA_* tables approach for SELECT_CATALOG_ROLE users' },
+				'Getting sequences',
+			);
+			queryApproach = 'DBA_* tables';
+
+			try {
+				const dbaTablesQuery = getSequencesQueryUsingDbaTables({ schema });
+				const dbaTablesResult = await execute(dbaTablesQuery);
+				rawSequenceDtos = dbaTablesResult.map(([rawSequence]) => JSON.parse(rawSequence));
+			} catch (dbaTablesError) {
+				logger.log(
+					'info',
+					{ message: 'DBA_* tables approach also failed, using empty result' },
+					'Getting sequences',
+				);
+				rawSequenceDtos = [];
+			}
+		}
 
 		logger.log(
 			'info',
-			{ message: 'Finish getting sequences', count: rawSequenceDtos?.length || 0 },
+			{
+				message: `Finish getting sequences using ${queryApproach}`,
+				count: rawSequenceDtos?.length || 0,
+				queryApproach,
+			},
 			'Getting sequences',
 		);
 

--- a/reverse_engineering/helpers/getSchemaSynonyms.js
+++ b/reverse_engineering/helpers/getSchemaSynonyms.js
@@ -1,0 +1,182 @@
+/**
+ * @typedef {Function} Execute
+ */
+
+const _ = require('lodash');
+
+/**
+ * Generates a SQL query to retrieve synonym information using ALL_* tables.
+ * This approach is used as a fallback for users who don't have access to DBA_* tables.
+ * Works for most Oracle users who have standard access privileges.
+ *
+ * @param {string} schema - The Oracle schema name to query synonyms from
+ * @returns {string} SQL query string for retrieving synonyms from ALL_* tables
+ */
+const getSynonymsQueryUsingAllTables = schema => {
+	return `
+		SELECT ALL_SYNONYMS.OWNER,
+		    ALL_SYNONYMS.SYNONYM_NAME,
+		    ALL_SYNONYMS.TABLE_NAME,
+		    ALL_OBJECTS.EDITIONABLE
+		  FROM ALL_SYNONYMS
+		  LEFT JOIN ALL_OBJECTS
+		    ON ALL_OBJECTS.OWNER = ALL_SYNONYMS.OWNER
+		    AND ALL_OBJECTS.OBJECT_NAME = ALL_SYNONYMS.SYNONYM_NAME
+		  WHERE ORIGIN_CON_ID > 1 AND ALL_SYNONYMS.TABLE_OWNER = '${schema}'
+	`;
+};
+
+/**
+ * Generates a SQL query to retrieve synonym information using DBA_* tables.
+ * This is the preferred approach as it provides richer results and access to all synonyms
+ * in the database. Requires SELECT_CATALOG_ROLE or equivalent privileges.
+ *
+ * @param {string} schema - The Oracle schema name to query synonyms from
+ * @returns {string} SQL query string for retrieving synonyms from DBA_* tables
+ */
+const getSynonymsQueryUsingDbaTables = schema => {
+	return `
+		SELECT DBA_SYNONYMS.OWNER,
+		    DBA_SYNONYMS.SYNONYM_NAME,
+		    DBA_SYNONYMS.TABLE_NAME,
+		    DBA_OBJECTS.EDITIONABLE
+		  FROM DBA_SYNONYMS
+		  LEFT JOIN DBA_OBJECTS
+		    ON DBA_OBJECTS.OWNER = DBA_SYNONYMS.OWNER
+		    AND DBA_OBJECTS.OBJECT_NAME = DBA_SYNONYMS.SYNONYM_NAME
+		  WHERE ORIGIN_CON_ID > 1 AND DBA_SYNONYMS.TABLE_OWNER = '${schema}'
+	`;
+};
+
+/**
+ * Retrieves synonyms from an Oracle schema with automatic fallback capability.
+ *
+ * This function implements a two-tier approach:
+ * 1. First attempts to use DBA_* tables (for users with SELECT_CATALOG_ROLE - provides richer results)
+ * 2. Falls back to ALL_* tables if DBA_* fails or returns empty results (standard approach for most users)
+ *
+ * The function filters out synonyms that are not actually used in the schema (referenced in DDL scripts).
+ *
+ * @param {{ schema: string, execute: Execute, logger: object, allDDLs: string }} params
+ * @param {string} params.schema - The Oracle schema name to retrieve synonyms from
+ * @param {Execute} params.execute - Database execution function for running SQL queries
+ * @param {object} params.logger - Logger instance for tracking progress and errors
+ * @param {string} params.allDDLs - All DDL scripts from the schema used to filter synonyms that are actually used
+ * @returns {Promise<Array>} Promise that resolves to an array of synonym objects
+ */
+const getSchemaSynonymDtos = async ({ schema, allDDLs, execute, logger }) => {
+	try {
+		logger.log('info', { message: 'Start getting synonyms' }, 'Getting synonyms');
+
+		let queryResult;
+		let queryApproach = 'DBA_* tables';
+		let shouldTryAllFallback = false;
+
+		try {
+			const dbaTablesQuery = getSynonymsQueryUsingDbaTables(schema);
+			queryResult = await execute(dbaTablesQuery);
+
+			if (!queryResult || queryResult.length === 0) {
+				shouldTryAllFallback = true;
+			}
+		} catch (dbaTablesError) {
+			logger.log(
+				'info',
+				{
+					message: 'DBA_* tables approach failed with exception, trying ALL_* tables fallback',
+					error: dbaTablesError.message,
+				},
+				'Getting synonyms',
+			);
+			shouldTryAllFallback = true;
+		}
+
+		if (shouldTryAllFallback) {
+			logger.log('info', { message: 'Trying ALL_* tables approach as fallback' }, 'Getting synonyms');
+			queryApproach = 'ALL_* tables';
+
+			try {
+				const allTablesQuery = getSynonymsQueryUsingAllTables(schema);
+				queryResult = await execute(allTablesQuery);
+			} catch (allTablesError) {
+				logger.log(
+					'info',
+					{ message: 'ALL_* tables approach also failed, using empty result', error: allTablesError.message },
+					'Getting synonyms',
+				);
+				queryResult = [];
+			}
+		}
+
+		logger.log(
+			'info',
+			{
+				message: `Finish getting synonyms using ${queryApproach}`,
+				count: queryResult?.length || 0,
+				queryApproach,
+			},
+			'Getting synonyms',
+		);
+
+		if (_.isEmpty(queryResult)) {
+			return [];
+		}
+
+		const synonyms = queryResult.map(([owner, synonymName, synonymEntityId, editionable]) => {
+			return {
+				synonymPublic: owner === 'PUBLIC',
+				synonymName,
+				synonymEntityId,
+				synonymEditionable: editionable === null || editionable === 'N' ? 'NONEDITIONABLE' : 'EDITIONABLE',
+			};
+		});
+
+		return filterUsedSynonyms({ synonyms, allDDLs });
+	} catch (err) {
+		logger.log(
+			'error',
+			{
+				message: 'Cannot get synonyms',
+				error: { message: err.message, stack: err.stack, err: _.omit(err, ['message', 'stack']) },
+			},
+			'Getting synonyms',
+		);
+		return [];
+	}
+};
+
+/**
+ * @param {{ execute: Execute }}
+ * @returns {({ schema, logger }: { schema: string, allDDLs: string, logger: object }) => Promise<Array>}
+ */
+const getSchemaSynonyms =
+	({ execute }) =>
+	async ({ schema, allDDLs, logger }) => {
+		return await getSchemaSynonymDtos({ schema, allDDLs, execute, logger });
+	};
+
+/**
+ * Filters synonyms to only include those that are actually used in the provided DDL scripts.
+ *
+ * @param {{ synonyms: Array<{ synonymName: string }>, allDDLs: string }} params
+ * @param {Array<{ synonymName: string }>} params.synonyms - Array of synonym objects to filter
+ * @param {string} params.allDDLs - All DDL scripts from the schema to search for synonym usage
+ * @returns {Array} Array of synonyms that are actually used in the DDL scripts
+ */
+const filterUsedSynonyms = ({ synonyms, allDDLs }) => {
+	const usedSynonyms = [];
+
+	for (const synonym of synonyms) {
+		const synonymRegexp = new RegExp('\\b' + synonym.synonymName + '\\b', 'i');
+
+		if (synonymRegexp.test(allDDLs)) {
+			usedSynonyms.push(synonym);
+		}
+	}
+
+	return usedSynonyms;
+};
+
+module.exports = {
+	getSchemaSynonyms,
+};

--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -426,7 +426,7 @@ const selectEntitiesWithFallback = async ({
 			stmt = `T.OWNER = '${schemaName}'`;
 		}
 		if (includeSystemCollection) {
-			const result = await execute(`${dbaSelectStatement}${stmt ? ` WHERE ${stmt}` : ''}`);
+			const result = await execute(dbaSelectStatement + (stmt ? ' WHERE ' + stmt : ''));
 			logger.info({ message: `Successfully retrieved ${entityType} using DBA_* tables` });
 			return result;
 		} else {

--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -5,6 +5,7 @@ const oracleDB = require('oracledb');
 const extractWallet = require('./extractWallet');
 const parseTns = require('./parseTns');
 const { getSchemaSequences } = require('./getSchemaSequences');
+const { getSchemaSynonyms } = require('./getSchemaSynonyms');
 
 const noConnectionError = { message: 'Connection error' };
 
@@ -1110,70 +1111,6 @@ const logEnvironment = logger => {
 	);
 };
 
-const getSchemaSynonyms = async ({ schema, allDDLs, logger }) => {
-	try {
-		logger.log('info', { message: 'Start getting synonyms' }, 'Getting synonyms');
-
-		const queryResult = await execute(
-			`
-			SELECT ALL_SYNONYMS.OWNER,
-			    ALL_SYNONYMS.SYNONYM_NAME,
-			    ALL_SYNONYMS.TABLE_NAME,
-			    ALL_OBJECTS.EDITIONABLE
-			  FROM ALL_SYNONYMS
-			  LEFT JOIN ALL_OBJECTS
-			    ON ALL_OBJECTS.OWNER = ALL_SYNONYMS.OWNER
-			    AND ALL_OBJECTS.OBJECT_NAME = ALL_SYNONYMS.SYNONYM_NAME
-			  WHERE ORIGIN_CON_ID > 1 AND ALL_SYNONYMS.TABLE_OWNER = '${schema}'
-			`,
-		);
-
-		logger.log('info', { message: 'Finish getting synonyms', count: queryResult?.length || 0 }, 'Getting synonyms');
-
-		if (_.isEmpty(queryResult)) {
-			return [];
-		}
-		const synonyms = queryResult.map(([owner, synonymName, synonymEntityId, editionable]) => {
-			return {
-				synonymPublic: owner === 'PUBLIC',
-				synonymName,
-				synonymEntityId,
-				synonymEditionable: editionable === null || editionable === 'N' ? 'NONEDITIONABLE' : 'EDITIONABLE',
-			};
-		});
-
-		return filterUsedSynonyms({ synonyms, allDDLs });
-	} catch (err) {
-		logger.log(
-			'error',
-			{
-				message: 'Cannot get synonyms',
-				error: { message: err.message, stack: err.stack, err: _.omit(err, ['message', 'stack']) },
-			},
-			'Getting synonyms',
-		);
-	}
-};
-
-/**
- *
- * @param {{ synonyms: Array<{ synonymName: string }>, allDDLs: string[] }}
- * @returns {Array}
- */
-const filterUsedSynonyms = ({ synonyms, allDDLs }) => {
-	const usedSynonyms = [];
-
-	for (const synonym of synonyms) {
-		const synonymRegexp = new RegExp('\\b' + synonym.synonymName + '\\b', 'i');
-
-		if (synonymRegexp.test(allDDLs)) {
-			usedSynonyms.push(synonym);
-		}
-	}
-
-	return usedSynonyms;
-};
-
 module.exports = {
 	connect,
 	disconnect,
@@ -1187,6 +1124,6 @@ module.exports = {
 	selectRecords,
 	logEnvironment,
 	execute,
-	getSchemaSynonyms,
+	getSchemaSynonyms: getSchemaSynonyms({ execute }),
 	getSchemaSequences: getSchemaSequences({ execute }),
 };

--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -595,7 +595,16 @@ const setSQLTerminator = () => {
 };
 
 /**
- * Generate table DDL if the user has limited access to ALL_* views
+ * Generates table DDL using individual DBMS_METADATA calls with DBA_* tables access.
+ *
+ * This function serves as a fallback mechanism when the primary getDDL function fails
+ * to retrieve data from ALL_* tables. It directly uses DBA_* tables which require
+ * elevated privileges such as SELECT_CATALOG_ROLE.
+ *
+ * @param {string} tableName - The name of the table to generate DDL for
+ * @param {string} schema - The Oracle schema name containing the table
+ * @param {object} logger - Logger instance for tracking progress and errors
+ * @returns {Promise<{ddl: string, jsonColumns: Array, countOfRecords: number}>} Promise that resolves to table DDL information
  */
 const generateDDLFromDataDictionary = async (tableName, schema, logger) => {
 	try {
@@ -688,6 +697,18 @@ const generateDDLFromDataDictionary = async (tableName, schema, logger) => {
 	}
 };
 
+/**
+ * Retrieves DDL (Data Definition Language) scripts for a table with automatic fallback capability.
+ *
+ * This function implements a two-tier approach for retrieving comprehensive table DDL:
+ * 1. First attempts to use ALL_* tables (ALL_TABLES, ALL_INDEXES, ALL_CONSTRAINTS, etc.) for most users
+ * 2. Falls back to DBA_* tables (via generateDDLFromDataDictionary) if ALL_* approach fails or returns null data
+ *
+ * @param {string} tableName - The name of the table to retrieve DDL for
+ * @param {string} schema - The Oracle schema name containing the table
+ * @param {object} logger - Logger instance for tracking progress and errors
+ * @returns {Promise<{ddl: string, jsonColumns: Array, countOfRecords: number}>} Promise that resolves to table DDL information
+ */
 const getDDL = async (tableName, schema, logger) => {
 	try {
 		await setSQLTerminator();
@@ -927,6 +948,18 @@ const getJsonSchema = async (jsonColumns, records) => {
 	return { properties };
 };
 
+/**
+ * Generates view DDL using individual DBMS_METADATA calls with DBA_* tables access.
+ *
+ * This function serves as a fallback mechanism when the primary getViewDDL function fails
+ * to retrieve data from ALL_* tables. It directly uses DBA_* tables which require
+ * elevated privileges such as SELECT_CATALOG_ROLE.
+ *
+ * @param {string} viewName - The name of the view or materialized view to generate DDL for
+ * @param {string} schema - The Oracle schema name containing the view
+ * @param {object} logger - Logger instance for tracking progress and errors
+ * @returns {Promise<string>} Promise that resolves to the view DDL script
+ */
 const generateViewDDLFromDataDictionary = async (viewName, schema, logger) => {
 	try {
 		logger.log('info', { viewName, schema }, 'Generating view DDL using individual DBMS_METADATA calls');
@@ -994,6 +1027,22 @@ const generateViewDDLFromDataDictionary = async (viewName, schema, logger) => {
 	}
 };
 
+/**
+ * Retrieves DDL (Data Definition Language) scripts for views and materialized views with automatic fallback capability.
+ *
+ * This function implements a two-tier approach for retrieving comprehensive view DDL:
+ * 1. First attempts to use ALL_* tables (ALL_VIEWS, ALL_MVIEWS, ALL_INDEXES) for most users
+ * 2. Falls back to DBA_* tables (via generateViewDDLFromDataDictionary) if ALL_* approach fails or returns null data
+ *
+ * The function handles both:
+ * - Regular views: Uses DBMS_METADATA.GET_DDL('VIEW', ...) from ALL_VIEWS
+ * - Materialized views: Uses DBMS_METADATA.GET_DDL('MATERIALIZED_VIEW', ...) from ALL_MVIEWS with associated indexes
+ *
+ * @param {string} viewName - The name of the view or materialized view to retrieve DDL for
+ * @param {string} schema - The Oracle schema name containing the view
+ * @param {object} logger - Logger instance for tracking progress and errors
+ * @returns {Promise<string>} Promise that resolves to the view DDL script
+ */
 const getViewDDL = async (viewName, schema, logger) => {
 	try {
 		const isMaterializedView = await checkEntityMaterializedView(viewName, { useDbaViews: false });

--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -412,17 +412,79 @@ const selectEntities = (selectStatement, includeSystemCollection, schemaName) =>
 	}
 };
 
-const tableNamesByUser = ({ includeSystemCollection, schemaName }) =>
-	selectEntities(`SELECT T.OWNER, T.TABLE_NAME FROM ALL_TABLES T`, includeSystemCollection, schemaName);
-const externalTableNamesByUser = ({ includeSystemCollection, schemaName }) =>
-	selectEntities(`SELECT T.OWNER, T.TABLE_NAME FROM ALL_EXTERNAL_TABLES T`, includeSystemCollection, schemaName);
-const viewNamesByUser = ({ includeSystemCollection, schemaName }) =>
-	selectEntities(`SELECT T.OWNER, T.VIEW_NAME || \' (v)\' FROM ALL_VIEWS T`, includeSystemCollection, schemaName);
-const materializedViewNamesByUser = ({ includeSystemCollection, schemaName }) =>
-	selectEntities(`SELECT T.OWNER, T.MVIEW_NAME || \' (v)\' FROM ALL_MVIEWS T`, includeSystemCollection, schemaName);
+const selectEntitiesWithFallback = async ({
+	dbaSelectStatement,
+	allSelectStatement,
+	includeSystemCollection,
+	schemaName,
+	entityType,
+	logger,
+}) => {
+	try {
+		let stmt = '';
+		if (schemaName) {
+			stmt = `T.OWNER = '${schemaName}'`;
+		}
+		if (includeSystemCollection) {
+			const result = await execute(`${dbaSelectStatement}${stmt ? ` WHERE ${stmt}` : ''}`);
+			logger.info({ message: `Successfully retrieved ${entityType} using DBA_* tables` });
+			return result;
+		} else {
+			const result = await execute(
+				`${dbaSelectStatement} WHERE T.OWNER NOT IN ('SYS', 'SYSTEM', 'DBSNMP', 'SYSMAN', 'OUTLN', 'MGMT_VIEW', 'FLOWS_FILES', 'MDSYS', 'ORDSYS', 'EXFSYS', 'WMSYS', 'APPQOSSYS', 'APEX_030200', 'APEX_PUBLIC_USER', 'SPATIAL_CSW_ADMIN_USR', 'SPATIAL_WFS_ADMIN_USR', 'XS$NULL', 'ORACLE_OCM', 'XDB', 'ANONYMOUS', 'CTXSYS', 'ORDDATA', 'SI_INFORMTN_SCHEMA', 'DVF', 'DVSYS', 'DBSFWUSER', 'FLOWS_040100', 'APEX_040100', 'DIP', 'OWBSYS_AUDIT', 'OWBSYS', 'SYSDG', 'SYSBACKUP', 'SYSKM', 'LBACSYS', 'GSMADMIN_INTERNAL', 'MDDATA', 'SYSRAC', 'GGSYS', 'WKPROXY', 'WK_TEST', 'WKUSER', 'REMOTE_SCHEDULER_AGENT', 'SYS$UMF', 'GSMCATUSER', 'GSMUSER', 'SYSRMAN', 'EJBCA_USER', 'AUDSYS', 'SSOXDSDB', 'PDBADMIN', 'ORDS_PUBLIC_USER', 'ORDS_METADATA')${
+					stmt ? ` AND ${stmt}` : ''
+				}`,
+			);
+			logger.info({ message: `Successfully retrieved ${entityType} using DBA_* tables` });
+			return result;
+		}
+	} catch (e) {
+		logger.info({
+			message: `Failed to access DBA_* tables for ${entityType}, falling back to ALL_* tables: ${e.message}`,
+		});
+		return selectEntities(allSelectStatement, includeSystemCollection, schemaName);
+	}
+};
+
+const tableNamesByUser = ({ includeSystemCollection, schemaName }, logger) =>
+	selectEntitiesWithFallback({
+		dbaSelectStatement: `SELECT T.OWNER, T.TABLE_NAME FROM DBA_TABLES T`,
+		allSelectStatement: `SELECT T.OWNER, T.TABLE_NAME FROM ALL_TABLES T`,
+		includeSystemCollection,
+		schemaName,
+		entityType: 'tables',
+		logger,
+	});
+const externalTableNamesByUser = ({ includeSystemCollection, schemaName }, logger) =>
+	selectEntitiesWithFallback({
+		dbaSelectStatement: `SELECT T.OWNER, T.TABLE_NAME FROM DBA_EXTERNAL_TABLES T`,
+		allSelectStatement: `SELECT T.OWNER, T.TABLE_NAME FROM ALL_EXTERNAL_TABLES T`,
+		includeSystemCollection,
+		schemaName,
+		entityType: 'external tables',
+		logger,
+	});
+const viewNamesByUser = ({ includeSystemCollection, schemaName }, logger) =>
+	selectEntitiesWithFallback({
+		dbaSelectStatement: `SELECT T.OWNER, T.VIEW_NAME || ' (v)' FROM DBA_VIEWS T`,
+		allSelectStatement: `SELECT T.OWNER, T.VIEW_NAME || ' (v)' FROM ALL_VIEWS T`,
+		includeSystemCollection,
+		schemaName,
+		entityType: 'views',
+		logger,
+	});
+const materializedViewNamesByUser = ({ includeSystemCollection, schemaName }, logger) =>
+	selectEntitiesWithFallback({
+		dbaSelectStatement: `SELECT T.OWNER, T.MVIEW_NAME || ' (v)' FROM DBA_MVIEWS T`,
+		allSelectStatement: `SELECT T.OWNER, T.MVIEW_NAME || ' (v)' FROM ALL_MVIEWS T`,
+		includeSystemCollection,
+		schemaName,
+		entityType: 'materialized views',
+		logger,
+	});
 
 const getEntitiesNames = async (connectionInfo, logger) => {
-	const materializedViews = await materializedViewNamesByUser(connectionInfo).catch(e => {
+	const materializedViews = await materializedViewNamesByUser(connectionInfo, logger).catch(e => {
 		logger.info({ message: 'Cannot retrieve materialized views' });
 		logger.error(e);
 
@@ -433,7 +495,7 @@ const getEntitiesNames = async (connectionInfo, logger) => {
 
 	const materializedViewsNames = materializedViews.map(nameArray => _.join(nameArray, '.').slice(0, -' (v)'.length));
 
-	const tables = await tableNamesByUser(connectionInfo)
+	const tables = await tableNamesByUser(connectionInfo, logger)
 		.then(tables => {
 			return _.reject(tables, tableNameArray => materializedViewsNames.includes(_.join(tableNameArray, '.')));
 		})
@@ -445,7 +507,7 @@ const getEntitiesNames = async (connectionInfo, logger) => {
 
 	logger.info({ tables });
 
-	const externalTables = await externalTableNamesByUser(connectionInfo).catch(e => {
+	const externalTables = await externalTableNamesByUser(connectionInfo, logger).catch(e => {
 		logger.info({ message: 'Cannot retrieve external tables' });
 		logger.error(e);
 
@@ -454,7 +516,7 @@ const getEntitiesNames = async (connectionInfo, logger) => {
 
 	logger.info({ externalTables });
 
-	const views = await viewNamesByUser(connectionInfo).catch(e => {
+	const views = await viewNamesByUser(connectionInfo, logger).catch(e => {
 		logger.info({ message: 'Cannot retrieve views' });
 		logger.error(e);
 

--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -593,6 +593,100 @@ const setSQLTerminator = () => {
 	END;`);
 };
 
+/**
+ * Generate table DDL if the user has limited access to ALL_* views
+ */
+const generateDDLFromDataDictionary = async (tableName, schema, logger) => {
+	try {
+		logger.log('info', { tableName, schema }, 'Generating DDL using individual DBMS_METADATA calls');
+
+		const tableDDLResult = await execute(
+			`SELECT DBMS_METADATA.GET_DDL('TABLE', '${tableName}', '${schema}') FROM DUAL`,
+		);
+		const tableDDL = tableDDLResult[0] ? await tableDDLResult[0][0].getData() : '';
+
+		// Get indexes (excluding constraint-backed indexes and system indexes)
+		const indexesResult = await execute(`
+			SELECT INDEX_NAME 
+			FROM DBA_INDEXES 
+			WHERE TABLE_OWNER = '${schema}' AND TABLE_NAME = '${tableName}'
+				AND INDEX_NAME NOT IN (
+					SELECT CONSTRAINT_NAME 
+					FROM DBA_CONSTRAINTS 
+					WHERE OWNER = '${schema}' AND TABLE_NAME = '${tableName}' AND CONSTRAINT_NAME IS NOT NULL
+				)
+				AND INDEX_NAME NOT LIKE 'SYS_%'
+				AND INDEX_NAME NOT LIKE 'BIN$%'
+				AND OWNER NOT IN ('SYS', 'SYSTEM', 'CTXSYS', 'MDSYS', 'XDB')
+		`);
+
+		const indexDDLs = [];
+		for (const [indexName] of indexesResult) {
+			try {
+				const indexDDLResult = await execute(
+					`SELECT DBMS_METADATA.GET_DDL('INDEX', '${indexName}', '${schema}') FROM DUAL`,
+				);
+				if (indexDDLResult[0]?.[0]) {
+					const indexDDL = await indexDDLResult[0][0].getData();
+					indexDDLs.push(indexDDL);
+				}
+			} catch (e) {
+				logger.log(
+					'info',
+					{ message: `Cannot get DDL for index ${indexName}: ${e.message}` },
+					'DDL Generation',
+				);
+			}
+		}
+
+		const tableComment = await execute(`
+			SELECT COMMENTS 
+			FROM DBA_TAB_COMMENTS 
+			WHERE OWNER = '${schema}' AND TABLE_NAME = '${tableName}' AND COMMENTS IS NOT NULL
+		`);
+
+		const columnComments = await execute(`
+			SELECT COLUMN_NAME, COMMENTS 
+			FROM DBA_COL_COMMENTS 
+			WHERE OWNER = '${schema}' AND TABLE_NAME = '${tableName}' AND COMMENTS IS NOT NULL
+		`);
+
+		let commentsSQL = '';
+		if (tableComment.length > 0) {
+			commentsSQL += `COMMENT ON TABLE ${escapeName(schema)}.${escapeName(tableName)} IS ${escapeComment(tableComment[0][0])};`;
+		}
+		if (columnComments.length > 0) {
+			const columnCommentsSQL = columnComments
+				.map(
+					([columnName, comment]) =>
+						`COMMENT ON COLUMN ${escapeName(schema)}.${escapeName(tableName)}.${escapeName(columnName)} IS ${escapeComment(comment)};`,
+				)
+				.join('\n');
+			commentsSQL += commentsSQL ? `\n${columnCommentsSQL}` : columnCommentsSQL;
+		}
+
+		return {
+			ddl: `${tableDDL}${indexDDLs.join('\n')}\n${commentsSQL}`,
+			jsonColumns: [],
+			countOfRecords: 0,
+		};
+	} catch (err) {
+		logger.log(
+			'error',
+			{
+				message: 'Cannot generate DDL using DBMS_METADATA calls: ' + tableName,
+				error: { message: err.message, stack: err.stack, err: _.omit(err, ['message', 'stack']) },
+			},
+			`Generating DDL using DBMS_METADATA for "${schema}"."${tableName}"`,
+		);
+		return {
+			ddl: '',
+			jsonColumns: [],
+			countOfRecords: 0,
+		};
+	}
+};
+
 const getDDL = async (tableName, schema, logger) => {
 	try {
 		await setSQLTerminator();
@@ -634,7 +728,17 @@ const getDDL = async (tableName, schema, logger) => {
 			FROM ALL_TABLES T
 			WHERE T.OWNER='${schema}' AND T.TABLE_NAME='${tableName}'
 		`);
+
 		const row = await _.first(_.first(queryResult))?.getData();
+		if (!row) {
+			logger.log(
+				'info',
+				{ message: 'DBMS_METADATA returned null data, using individual DBMS_METADATA calls fallback' },
+				`Getting DDL from "${schema}"."${tableName}"`,
+			);
+			return await generateDDLFromDataDictionary(tableName, schema, logger);
+		}
+
 		try {
 			const queryObj = JSON.parse(row);
 			logger.log('info', queryObj, `Getting DDL from "${schema}"."${tableName}"`);
@@ -822,9 +926,76 @@ const getJsonSchema = async (jsonColumns, records) => {
 	return { properties };
 };
 
+const generateViewDDLFromDataDictionary = async (viewName, schema, logger) => {
+	try {
+		logger.log('info', { viewName, schema }, 'Generating view DDL using individual DBMS_METADATA calls');
+
+		const isMaterializedView = await checkEntityMaterializedView(viewName, { useDbaViews: true });
+
+		if (!isMaterializedView) {
+			// Regular view
+			const viewDDLResult = await execute(
+				`SELECT DBMS_METADATA.GET_DDL('VIEW', '${viewName}', '${schema}') FROM DUAL`,
+			);
+			const viewDDL = viewDDLResult[0] ? await viewDDLResult[0][0].getData() : '';
+			return viewDDL;
+		}
+
+		const mvDDLResult = await execute(
+			`SELECT DBMS_METADATA.GET_DDL('MATERIALIZED_VIEW', '${viewName}', '${schema}') FROM DUAL`,
+		);
+		const mvDDL = mvDDLResult[0] ? await mvDDLResult[0][0].getData() : '';
+
+		const indexesResult = await execute(`
+				SELECT INDEX_NAME 
+				FROM DBA_INDEXES 
+				WHERE TABLE_OWNER = '${schema}' AND TABLE_NAME = '${viewName}'
+					AND INDEX_NAME NOT IN (
+						SELECT CONSTRAINT_NAME 
+						FROM DBA_CONSTRAINTS 
+						WHERE OWNER = '${schema}' AND TABLE_NAME = '${viewName}' AND CONSTRAINT_NAME IS NOT NULL
+					)
+					AND INDEX_NAME NOT LIKE 'SYS_%'
+					AND INDEX_NAME NOT LIKE 'BIN$%'
+					AND OWNER NOT IN ('SYS', 'SYSTEM', 'CTXSYS', 'MDSYS', 'XDB')
+			`);
+
+		const indexDDLs = [];
+		for (const [indexName] of indexesResult) {
+			try {
+				const indexDDLResult = await execute(
+					`SELECT DBMS_METADATA.GET_DDL('INDEX', '${indexName}', '${schema}') FROM DUAL`,
+				);
+				if (indexDDLResult[0]?.[0]) {
+					const indexDDL = await indexDDLResult[0][0].getData();
+					indexDDLs.push(indexDDL);
+				}
+			} catch (e) {
+				logger.log(
+					'info',
+					{ message: `Cannot get DDL for index ${indexName}: ${e.message}` },
+					'View DDL Generation',
+				);
+			}
+		}
+
+		return mvDDL + (indexDDLs.length > 0 ? `\n${indexDDLs.join('\n')}` : '');
+	} catch (err) {
+		logger.log(
+			'error',
+			{
+				message: 'Cannot generate view DDL using DBMS_METADATA calls: ' + viewName,
+				error: { message: err.message, stack: err.stack, err: _.omit(err, ['message', 'stack']) },
+			},
+			`Generating view DDL using DBMS_METADATA for "${schema}"."${viewName}"`,
+		);
+		return '';
+	}
+};
+
 const getViewDDL = async (viewName, schema, logger) => {
 	try {
-		const isMaterializedView = await checkEntityMaterializedView(viewName);
+		const isMaterializedView = await checkEntityMaterializedView(viewName, { useDbaViews: false });
 
 		await setSQLTerminator();
 		if (isMaterializedView) {
@@ -861,7 +1032,17 @@ const getViewDDL = async (viewName, schema, logger) => {
 			`SELECT DBMS_METADATA.GET_DDL('VIEW', VIEW_NAME, OWNER) FROM ALL_VIEWS WHERE VIEW_NAME='${viewName}'`,
 		);
 
-		const viewDDL = await _.first(_.first(queryResult)).getData();
+		const firstResult = _.first(_.first(queryResult));
+		if (!firstResult) {
+			logger.log(
+				'info',
+				{ message: 'DBMS_METADATA returned null data for view, using individual DBMS_METADATA calls fallback' },
+				`Getting DDL for view "${schema}"."${viewName}"`,
+			);
+			return await generateViewDDLFromDataDictionary(viewName, schema, logger);
+		}
+
+		const viewDDL = await firstResult.getData();
 
 		return viewDDL;
 	} catch (err) {
@@ -881,11 +1062,16 @@ const getViewDDL = async (viewName, schema, logger) => {
 	}
 };
 
-const checkEntityMaterializedView = async name => {
+const checkEntityMaterializedView = async (name, options = {}) => {
+	const { useDbaViews = false } = options;
 	await setSQLTerminator();
-	const queryResult = await execute(`SELECT * FROM ALL_MVIEWS WHERE MVIEW_NAME = '${name}'`);
-
-	return !_.isEmpty(queryResult);
+	const viewType = useDbaViews ? 'DBA_MVIEWS' : 'ALL_MVIEWS';
+	try {
+		const queryResult = await execute(`SELECT * FROM ${viewType} WHERE MVIEW_NAME = '${name}'`);
+		return !_.isEmpty(queryResult);
+	} catch {
+		return false;
+	}
 };
 
 const checkUserHaveRequiredRole = async logger => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12973" title="HCK-12973" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12973</a>  Graceful degradation to RE without data access
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR implements a comprehensive privilege-aware approach for Oracle database reverse engineering that gracefully handles different user access levels.

**Problem Statement**
Previously, the Oracle plugin only queried `ALL_*` tables, which limited access to database objects based on user privileges.
Users with elevated privileges like `SELECT_CATALOG_ROLE`, who have access to `DBA_*` tables, couldn't benefit from the richer dataset these tables provide.

**Solution Overview**
Added a two-tier fallback mechanism that:
First attempts to query `DBA_*` tables (for users with `SELECT_CATALOG_ROLE` or equivalent privileges).
Falls back to `ALL_*` tables if `DBA_*` access fails or returns empty results.
This approach ensures backward compatibility - all existing users continue to work exactly as before, while users with elevated privileges now get enhanced functionality.