### PR TITLE
HCK-13007: rename tables and views

### DIFF
--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -144,7 +144,7 @@ const getAlterCollectionsScriptDtos = ({
  * @param app {App}
  * @param dbVersion {string}
  * @param scriptFormat {string}
- * @return {{ regularScripts: AlterScriptDto[], prioritizedScripts: AlterScriptDto[]}}
+ * @return {{ restViewScripts: AlterScriptDto[], renameViewScripts: AlterScriptDto[]}}
  * */
 const getAlterViewScriptDtos = (collection, app, dbVersion, scriptFormat) => {
 	const properties = collection.properties?.views?.properties;
@@ -171,23 +171,23 @@ const getAlterViewScriptDtos = (collection, app, dbVersion, scriptFormat) => {
 
 	const preparedModifyViewsScriptDtos = prepareDtos(properties.modified).reduce(
 		(scripts, view) => {
-			const { regularScripts, prioritizedScripts } = getModifyViewScriptDtos({ scriptFormat })(view);
+			const { restViewScripts, renameViewScripts } = getModifyViewScriptDtos({ scriptFormat })(view);
 
-			regularScripts.length && scripts.regularScripts.push(...regularScripts);
-			prioritizedScripts.length && scripts.prioritizedScripts.push(...prioritizedScripts);
+			restViewScripts.length && scripts.restViewScripts.push(...restViewScripts);
+			renameViewScripts.length && scripts.renameViewScripts.push(...renameViewScripts);
 
 			return scripts;
 		},
-		{ regularScripts: [], prioritizedScripts: [] },
+		{ restViewScripts: [], renameViewScripts: [] },
 	);
 
 	return {
-		regularScripts: [
+		restViewScripts: [
 			...deleteViewsScriptDtos,
 			...createViewsScriptDtos,
-			...preparedModifyViewsScriptDtos.regularScripts,
+			...preparedModifyViewsScriptDtos.restViewScripts,
 		].filter(Boolean),
-		prioritizedScripts: preparedModifyViewsScriptDtos.prioritizedScripts,
+		renameViewScripts: preparedModifyViewsScriptDtos.renameViewScripts,
 	};
 };
 
@@ -426,9 +426,9 @@ const getAlterScriptDtos = (data, app) => {
 		...containersScriptDtos,
 		...containersSequencesScriptDtos,
 		...modelDefinitionsScriptDtos,
-		...viewScriptDtos.prioritizedScripts,
+		...viewScriptDtos.renameViewScripts,
 		...collectionsScriptDtos,
-		...viewScriptDtos.regularScripts,
+		...viewScriptDtos.restViewScripts,
 		...relationshipScriptDtos,
 	]
 		.filter(Boolean)

--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -144,32 +144,51 @@ const getAlterCollectionsScriptDtos = ({
  * @param app {App}
  * @param dbVersion {string}
  * @param scriptFormat {string}
- * @return {AlterScriptDto[]}
+ * @return {{ regularScripts: AlterScriptDto[], prioritizedScripts: AlterScriptDto[]}}
  * */
 const getAlterViewScriptDtos = (collection, app, dbVersion, scriptFormat) => {
-	const createViewsScriptDtos = []
-		.concat(collection.properties?.views?.properties?.added?.items)
-		.filter(Boolean)
-		.map(item => Object.values(item.properties)[0])
-		.map(view => ({ ...view, ...(view.role || {}) }))
+	const properties = collection.properties?.views?.properties;
+	if (!properties) {
+		return [];
+	}
+
+	const prepareDtos = mutationType => {
+		if (!mutationType.items) {
+			return [];
+		}
+
+		return [mutationType.items]
+			.filter(Boolean)
+			.map(item => Object.values(item.properties)[0])
+			.map(view => ({ ...view, ...(view.role || {}) }));
+	};
+
+	const createViewsScriptDtos = prepareDtos(properties.added)
 		.filter(view => view.compMod?.created)
 		.map(getAddViewScriptDto(app, scriptFormat));
 
-	const deleteViewsScriptDtos = []
-		.concat(collection.properties?.views?.properties?.deleted?.items)
-		.filter(Boolean)
-		.map(item => Object.values(item.properties)[0])
-		.map(view => ({ ...view, ...(view.role || {}) }))
-		.map(getDeleteViewScriptDto(app, scriptFormat));
+	const deleteViewsScriptDtos = prepareDtos(properties.deleted).map(getDeleteViewScriptDto(app, scriptFormat));
 
-	const modifyViewsScriptDtos = []
-		.concat(collection.properties?.views?.properties?.modified?.items)
-		.filter(Boolean)
-		.map(viewWrapper => Object.values(viewWrapper.properties)[0])
-		.map(view => ({ ...view, ...(view.role || {}) }))
-		.flatMap(getModifyViewScriptDtos({ scriptFormat }));
+	const preparedModifyViewsScriptDtos = prepareDtos(properties.modified).reduce(
+		(scripts, view) => {
+			const { regularScripts, prioritizedScripts } = getModifyViewScriptDtos({ scriptFormat })(view);
 
-	return [...deleteViewsScriptDtos, ...createViewsScriptDtos, ...modifyViewsScriptDtos].filter(Boolean);
+			regularScripts.length && scripts.regularScripts.push(...regularScripts);
+			prioritizedScripts.length && scripts.prioritizedScripts.push(...prioritizedScripts);
+
+			return scripts;
+		},
+		{ regularScripts: [], prioritizedScripts: [] },
+	);
+
+	return {
+		regularScripts: [
+			...deleteViewsScriptDtos,
+			...createViewsScriptDtos,
+			...preparedModifyViewsScriptDtos.regularScripts,
+		].filter(Boolean),
+		prioritizedScripts: preparedModifyViewsScriptDtos.prioritizedScripts,
+	};
 };
 
 /**
@@ -372,8 +391,11 @@ const getAlterScriptDtos = (data, app) => {
 	const modelDefinitions = JSON.parse(data.modelDefinitions);
 	const internalDefinitions = JSON.parse(data.internalDefinitions);
 	const externalDefinitions = JSON.parse(data.externalDefinitions);
+
 	const dbVersion = data.modelData[0]?.dbVersion;
+
 	const containersScriptDtos = getAlterContainersScriptDtos({ collection, app, scriptFormat });
+
 	const collectionsScriptDtos = getAlterCollectionsScriptDtos({
 		collection,
 		app,
@@ -383,7 +405,9 @@ const getAlterScriptDtos = (data, app) => {
 		externalDefinitions,
 		scriptFormat,
 	});
+
 	const viewScriptDtos = getAlterViewScriptDtos(collection, app, dbVersion, scriptFormat);
+
 	const modelDefinitionsScriptDtos = getAlterModelDefinitionsScriptDtos({
 		collection,
 		app,
@@ -393,15 +417,18 @@ const getAlterScriptDtos = (data, app) => {
 		externalDefinitions,
 		scriptFormat,
 	});
+
 	const relationshipScriptDtos = getAlterRelationshipsScriptDtos({ collection, app, scriptFormat });
+
 	const containersSequencesScriptDtos = getAlterContainersSequencesScriptDtos({ collection, app, dbVersion });
 
 	return [
 		...containersScriptDtos,
 		...containersSequencesScriptDtos,
 		...modelDefinitionsScriptDtos,
+		...viewScriptDtos.prioritizedScripts,
 		...collectionsScriptDtos,
-		...viewScriptDtos,
+		...viewScriptDtos.regularScripts,
 		...relationshipScriptDtos,
 	]
 		.filter(Boolean)

--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -157,7 +157,7 @@ const getAlterViewScriptDtos = (collection, app, dbVersion, scriptFormat) => {
 			return [];
 		}
 
-		return [mutationType.items]
+		return mutationType.items
 			.filter(Boolean)
 			.map(item => Object.values(item.properties)[0])
 			.map(view => ({ ...view, ...(view.role || {}) }));

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -12,6 +12,7 @@ const {
 const { getModifyCheckConstraintScriptDtos } = require('./entityHelpers/checkConstraintHelper');
 const { getModifyPkConstraintsScriptDtos } = require('./entityHelpers/primaryKeyHelper');
 const { getModifyUniqueKeyConstraintsScriptDtos } = require('./entityHelpers/uniqueKeyHelper');
+const { getModifyCollectionNameScriptDtos } = require('./entityHelpers/nameHelper');
 const { getModifyNonNullColumnsScriptDtos } = require('./columnHelpers/nonNullConstraintHelper');
 const { getModifiedDefaultColumnValueScriptDtos } = require('./columnHelpers/defaultValueHelper');
 const { getModifyEntityCommentsScriptDtos } = require('./entityHelpers/commentsHelper');
@@ -103,8 +104,10 @@ const getModifyCollectionScriptDtos =
 		const modifyUniqueKeyConstraintDtos = getModifyUniqueKeyConstraintsScriptDtos({ scriptFormat, collection });
 		const modifyCheckConstraintScriptDtos = getModifyCheckConstraintScriptDtos({ scriptFormat })(collection);
 		const modifyIndexesScriptDtos = getModifyIndexesScriptDtos({ ddlProvider, scriptFormat })({ collection });
+		const modifyEntityNameScriptDtos = getModifyCollectionNameScriptDtos({ scriptFormat, collection });
 
 		return [
+			...modifyEntityNameScriptDtos,
 			...modifyPKConstraintDtos,
 			...modifyCommentScriptDtos,
 			...modifyUniqueKeyConstraintDtos,

--- a/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
@@ -3,6 +3,7 @@ const { AlterScriptDto } = require('../types/AlterScriptDto');
 const { mapDeltaDualityViewToFeDualityView } = require('./dualityViewHelpers/deltaDualityViewToFeDualityViewMapper');
 const { prepareNameForScriptFormat } = require('../../utils/general');
 const { getModifyViewCommentsScriptDtos } = require('./viewHelpers/commentsHelper');
+const { getModifyEntityNameScriptDtos } = require('./viewHelpers/nameHelper');
 
 /**
  * @return {(view: Object) => AlterScriptDto | undefined}
@@ -66,14 +67,20 @@ const getDeleteViewScriptDto = (app, scriptFormat) => view => {
 /**
  * @param {object} params
  * @property {string} [scriptFormat]
- * @return {(view: AlterCollectionDto) => AlterScriptDto[]}
+ * @return {(view: AlterCollectionDto) => { regularScripts: AlterScriptDto[], prioritizedScripts: AlterScriptDto[] }}
  * */
 const getModifyViewScriptDtos =
 	({ scriptFormat }) =>
 	view => {
 		const modifyCommentsScriptDtos = getModifyViewCommentsScriptDtos({ scriptFormat, view });
 
-		return [...modifyCommentsScriptDtos].filter(Boolean);
+		// RENAME view statements must go *before* renaming table statements
+		const modifyEntityNameScriptDtos = getModifyEntityNameScriptDtos({ scriptFormat, entity: view });
+
+		const regularScripts = [...modifyCommentsScriptDtos].filter(Boolean);
+		const prioritizedScripts = [...modifyEntityNameScriptDtos].filter(Boolean);
+
+		return { regularScripts, prioritizedScripts };
 	};
 
 const getKeys = ({ view, collectionRefsDefinitionsMap, ddlProvider, app }) => {

--- a/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
@@ -67,7 +67,7 @@ const getDeleteViewScriptDto = (app, scriptFormat) => view => {
 /**
  * @param {object} params
  * @property {string} [scriptFormat]
- * @return {(view: AlterCollectionDto) => { regularScripts: AlterScriptDto[], prioritizedScripts: AlterScriptDto[] }}
+ * @return {(view: AlterCollectionDto) => { restViewScripts: AlterScriptDto[], renameViewScripts: AlterScriptDto[] }}
  * */
 const getModifyViewScriptDtos =
 	({ scriptFormat }) =>
@@ -77,10 +77,10 @@ const getModifyViewScriptDtos =
 		// RENAME view statements must go *before* renaming table statements
 		const modifyEntityNameScriptDtos = getModifyEntityNameScriptDtos({ scriptFormat, entity: view });
 
-		const regularScripts = [...modifyCommentsScriptDtos].filter(Boolean);
-		const prioritizedScripts = [...modifyEntityNameScriptDtos].filter(Boolean);
+		const restViewScripts = modifyCommentsScriptDtos.filter(Boolean);
+		const renameViewScripts = modifyEntityNameScriptDtos.filter(Boolean);
 
-		return { regularScripts, prioritizedScripts };
+		return { restViewScripts, renameViewScripts };
 	};
 
 const getKeys = ({ view, collectionRefsDefinitionsMap, ddlProvider, app }) => {

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
@@ -1,0 +1,57 @@
+const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterCollectionDto } = require('../../types/AlterCollectionDto');
+const { assignTemplates } = require('../../../utils/assignTemplates');
+const {
+	prepareNameForScriptFormat,
+	getSchemaOfAlterCollection,
+	getNamePrefixedWithSchemaNameForScriptFormat,
+} = require('../../../utils/general');
+const templates = require('../../../ddlProvider/templates');
+
+/**
+ * @param {object} params
+ * @property {string} params.scriptFormat
+ * @property {AlterCollectionDto} params.collection
+ * @return {AlterScriptDto}
+ */
+const getRenameCollectionScriptDto = ({ scriptFormat, collection }) => {
+	const collectionName = collection?.role?.compMod?.collectionName;
+
+	if (!collectionName) {
+		return undefined;
+	}
+
+	const { old: name, new: newName } = collectionName;
+
+	if (!newName || newName === name) {
+		return undefined;
+	}
+
+	const collectionSchema = getSchemaOfAlterCollection(collection);
+	const bucketName = collectionSchema.compMod?.keyspaceName;
+
+	const fullTableName = getNamePrefixedWithSchemaNameForScriptFormat(scriptFormat)(name, bucketName);
+
+	const script = assignTemplates(templates.renameTable, {
+		tableName: fullTableName,
+		newName: prepareNameForScriptFormat(scriptFormat)(newName),
+	});
+
+	return AlterScriptDto.getInstance([script], true, false);
+};
+
+/**
+ * @param {object} params
+ * @param {string} params.scriptFormat
+ * @param {AlterCollectionDto} params.collection
+ * @return {Array<AlterScriptDto>}
+ * */
+const getModifyCollectionNameScriptDtos = ({ scriptFormat, collection }) => {
+	const renameEntityScript = getRenameCollectionScriptDto({ scriptFormat, collection });
+
+	return [renameEntityScript].filter(Boolean);
+};
+
+module.exports = {
+	getModifyCollectionNameScriptDtos,
+};

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
@@ -49,7 +49,7 @@ const getRenameCollectionScriptDto = ({ scriptFormat, collection }) => {
 const getModifyCollectionNameScriptDtos = ({ scriptFormat, collection }) => {
 	const renameEntityScript = getRenameCollectionScriptDto({ scriptFormat, collection });
 
-	return [renameEntityScript].filter(Boolean);
+	return [renameEntityScript];
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/viewHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/viewHelpers/nameHelper.js
@@ -1,0 +1,54 @@
+const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterCollectionDto } = require('../../types/AlterCollectionDto');
+const { assignTemplates } = require('../../../utils/assignTemplates');
+const { prepareNameForScriptFormat } = require('../../../utils/general');
+const templates = require('../../../ddlProvider/templates');
+
+/**
+ * @param {object} params
+ * @property {string} params.scriptFormat
+ * @property {AlterCollectionDto} params.entity
+ * @return {AlterScriptDto}
+ */
+const getRenameEntityScriptDto = ({ scriptFormat, entity }) => {
+	const entityName = entity?.role?.compMod?.name;
+
+	if (!entityName) {
+		return undefined;
+	}
+
+	const { old: name, new: newName } = entityName;
+
+	if (!newName || newName === name) {
+		return undefined;
+	}
+
+	const renameScript = assignTemplates(templates.renameEntity, {
+		name: prepareNameForScriptFormat(scriptFormat)(name),
+		newName: prepareNameForScriptFormat(scriptFormat)(newName),
+	});
+
+	const schemaName = prepareNameForScriptFormat(scriptFormat)(entity.role.compMod.keyspaceName);
+
+	const alterSessionScript = assignTemplates(templates.alterSession, {
+		schemaName,
+	});
+
+	return AlterScriptDto.getInstance([alterSessionScript, renameScript], true, false);
+};
+
+/**
+ * @param {object} params
+ * @param {string} params.scriptFormat
+ * @param {AlterCollectionDto} params.entity
+ * @return {Array<AlterScriptDto>}
+ * */
+const getModifyEntityNameScriptDtos = ({ scriptFormat, entity }) => {
+	const renameEntityScript = getRenameEntityScriptDto({ scriptFormat, entity });
+
+	return [renameEntityScript].filter(Boolean);
+};
+
+module.exports = {
+	getModifyEntityNameScriptDtos,
+};

--- a/forward_engineering/ddlProvider/ddlHelpers/sequenceHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/sequenceHelper.js
@@ -74,7 +74,7 @@ module.exports = ({ templates, assignTemplates, getNamePrefixedWithSchemaName, w
 		 */
 		const configs = [
 			{ key: 'options', value: options, name: fullName, template: templates.alterSequence },
-			{ key: 'newName', value: newName, name: wrappedSequenceName, template: templates.renameSequence },
+			{ key: 'newName', value: newName, name: wrappedSequenceName, template: templates.renameEntity },
 		];
 
 		return configs

--- a/forward_engineering/ddlProvider/templates.js
+++ b/forward_engineering/ddlProvider/templates.js
@@ -52,7 +52,11 @@ module.exports = {
 
 	dropSequence: 'DROP SEQUENCE${ifExists} ${name};\n',
 
-	renameSequence: 'RENAME ${name} TO ${newName};\n',
+	// works for tables, views, sequences, synonyms, and private user-owned objects
+	// Note: can't have full path, prefixed with schema name. Only works on objects in your current schema.
+	renameEntity: 'RENAME ${name} TO ${newName};\n',
+
+	renameTable: 'ALTER TABLE ${tableName} RENAME TO ${newName};\n',
 
 	alterSequence: 'ALTER SEQUENCE${ifExists} ${name}' + '${options};\n',
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13007" title="HCK-13007" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-13007</a>  [BBVA][Oracle] Rename views and entities in alter script of delta model
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

* added rename Table and View in alter scripts

## Technical details

*  `RENAME` only works on objects in the _current_ schema. So when there are name changes in multiple schemas we will use [alterSession](https://github.com/hackolade/Oracle/compare/feat/HCK-13007-alter-entities-names?expand=1#diff-88d5684ecf833152ebfa3bbad5d3208b887e8a5e48a6a425fc9c644905f69a81R33) script to properly address the correct view. It shouldn't affect other statements as in most cases we use absolute paths to objects (i.e. `schema.table.column`)