### PR TITLE
HCK-13105: allow json data type for new oracle dbversion 26ai (if not duality vi…

### DIFF
--- a/types/json.json
+++ b/types/json.json
@@ -21,9 +21,19 @@
 				"type": "and",
 				"values": [
 					{
-						"level": "model",
-						"key": "dbVersion",
-						"value": "23ai"
+						"type": "or",
+						"values": [
+							{
+								"level": "model",
+								"key": "dbVersion",
+								"value": "23ai"
+							},
+							{
+								"level": "model",
+								"key": "dbVersion",
+								"value": "26ai"
+							}
+						]
 					},
 					{
 						"type": "or",

--- a/types/json.json
+++ b/types/json.json
@@ -13,25 +13,25 @@
 		"type": "or",
 		"values": [
 			{
-				"level": "model",
-				"key": "dbVersion",
-				"value": "21c"
-			},
-			{
 				"type": "and",
 				"values": [
 					{
-						"type": "or",
+						"type": "not",
 						"values": [
 							{
 								"level": "model",
 								"key": "dbVersion",
-								"value": "23ai"
+								"value": "12c"
 							},
 							{
 								"level": "model",
 								"key": "dbVersion",
-								"value": "26ai"
+								"value": "18c"
+							},
+							{
+								"level": "model",
+								"key": "dbVersion",
+								"value": "19c"
 							}
 						]
 					},

--- a/types/json.json
+++ b/types/json.json
@@ -10,45 +10,40 @@
 		"source": true
 	},
 	"dependency": {
-		"type": "or",
+		"type": "and",
 		"values": [
 			{
-				"type": "and",
+				"type": "not",
 				"values": [
 					{
-						"type": "not",
-						"values": [
-							{
-								"level": "model",
-								"key": "dbVersion",
-								"value": "12c"
-							},
-							{
-								"level": "model",
-								"key": "dbVersion",
-								"value": "18c"
-							},
-							{
-								"level": "model",
-								"key": "dbVersion",
-								"value": "19c"
-							}
-						]
+						"level": "model",
+						"key": "dbVersion",
+						"value": "12c"
 					},
 					{
-						"type": "or",
-						"values": [
-							{
-								"level": "root",
-								"key": "duality",
-								"value": false
-							},
-							{
-								"level": "root",
-								"key": "duality",
-								"exist": false
-							}
-						]
+						"level": "model",
+						"key": "dbVersion",
+						"value": "18c"
+					},
+					{
+						"level": "model",
+						"key": "dbVersion",
+						"value": "19c"
+					}
+				]
+			},
+			{
+				"type": "or",
+				"values": [
+					{
+						"level": "root",
+						"key": "duality",
+						"value": false
+					},
+					{
+						"level": "root",
+						"key": "duality",
+						"exist": false
 					}
 				]
 			}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13105" title="HCK-13105" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-13105</a>  Enable json data type
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Improved config of json data type for Oracle to allow it in 26ai, similarly to 23ai