### PR TITLE
HCK-13107: enable duality views for 23ai and newer db versions

### DIFF
--- a/properties_pane/view_level/viewLevelConfig.json
+++ b/properties_pane/view_level/viewLevelConfig.json
@@ -112,9 +112,29 @@
 					"type": "and",
 					"values": [
 						{
-							"level": "model",
-							"key": "dbVersion",
-							"value": "23ai"
+							"type": "not",
+							"values": [
+								{
+									"level": "model",
+									"key": "dbVersion",
+									"value": "12c"
+								},
+								{
+									"level": "model",
+									"key": "dbVersion",
+									"value": "18c"
+								},
+								{
+									"level": "model",
+									"key": "dbVersion",
+									"value": "19c"
+								},
+								{
+									"level": "model",
+									"key": "dbVersion",
+									"value": "21c"
+								}
+							]
 						},
 						{
 							"type": "or",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13107" title="HCK-13107" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-13107</a>  Configure duality checkbox in viewLevelConfig with black list of version that are not allowed (future-proof)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Adjusted the duality view configuration to enable support for Oracle 23ai, 26ai, and newer versions.