### PR TITLE
HCK-13106: run attribute types adapter for 26ai DB version

### DIFF
--- a/properties_pane/model_level/modelLevelConfig.json
+++ b/properties_pane/model_level/modelLevelConfig.json
@@ -159,6 +159,18 @@ making sure that you maintain a proper JSON format.
 							]
 						},
 						"adapter": "adaptUnavailableTypes"
+					},
+					{
+						"dependency": {
+							"type": "not",
+							"values": [
+								{
+									"key": "dbVersion",
+									"value": "26ai"
+								}
+							]
+						},
+						"adapter": "adaptUnavailableTypes"
 					}
 				]
 			},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13106" title="HCK-13106" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-13106</a>  Switching to lower version should adapt unavailable types
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Enabled the attribute types adapter, which runs while switching from 26ai to any other version.
It will show a false-positive warning for the 26ai->23ai switch, it won't affect any model attributes.
This case will be handled in a separate PR.
