### PR TITLE
HCK-13108: add new 26ai DB version for RE

### DIFF
--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -587,8 +587,8 @@ const execute = (command, options = {}, binds = []) => {
 };
 
 const getDbVersion = async logger => {
-	const versions = ['12c', '18c', '19c', '21c', '23ai'];
-	const defaultVersion = '21c';
+	const versions = ['12c', '18c', '19c', '21c', '23ai', '26ai'];
+	const fallbackDbVersion = '21c';
 
 	try {
 		const versionTable = await execute(
@@ -600,15 +600,15 @@ const getDbVersion = async logger => {
 		const majorVersion = versionTable?.[0]?.[0]?.split('.').shift();
 
 		if (!majorVersion) {
-			return defaultVersion;
+			return fallbackDbVersion;
 		}
 
-		const currentVersion = versions.find(version => version.startsWith(majorVersion));
+		const foundDbVersion = versions.find(version => version.startsWith(majorVersion));
 
-		return currentVersion || defaultVersion;
+		return foundDbVersion || fallbackDbVersion;
 	} catch (e) {
 		logger.log('error', { message: e.message, stack: e.stack }, 'Error of getting DB Version');
-		return defaultVersion;
+		return fallbackDbVersion;
 	}
 };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13108" title="HCK-13108" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-13108</a>  Adapt RE from instance to recognize new version 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR adds detecting the newly added 26ai DB version in reverse engineering.