### PR TITLE
HCk-13108: fix matching 26ai DB version in RE

### DIFF
--- a/reverse_engineering/helpers/oracleHelper.js
+++ b/reverse_engineering/helpers/oracleHelper.js
@@ -591,16 +591,29 @@ const getDbVersion = async logger => {
 	const fallbackDbVersion = '21c';
 
 	try {
-		const versionTable = await execute(
-			"SELECT VERSION FROM PRODUCT_COMPONENT_VERSION WHERE product LIKE 'Oracle Database%'",
+		const dbVersionResponse = await execute(
+			"SELECT version_full FROM product_component_version WHERE product LIKE 'Oracle Database%'",
 		);
-
-		logger.log('info', versionTable, 'DB Version');
-
-		const majorVersion = versionTable?.[0]?.[0]?.split('.').shift();
+		const dbVersion = dbVersionResponse?.[0]?.[0];
+		logger.log('info', dbVersion, 'DB Version');
+		const versionParts = dbVersion?.split('.');
+		const majorVersion = versionParts?.[0];
 
 		if (!majorVersion) {
 			return fallbackDbVersion;
+		}
+
+		const minorVersion = versionParts?.[1];
+
+		// For Oracle 23+, use the minor version to determine the target version
+		// e.g., 23.26.1.0.0 -> 26ai or 23ai (fallback)
+		if (majorVersion === '23' && minorVersion) {
+			const targetVersion = `${minorVersion}ai`;
+			if (versions.includes(targetVersion)) {
+				return targetVersion;
+			}
+
+			return versions.includes('23ai') ? '23ai' : fallbackDbVersion;
 		}
 
 		const foundDbVersion = versions.find(version => version.startsWith(majorVersion));


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13108" title="HCK-13108" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-13108</a>  Adapt RE from instance to recognize new version 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

The release numbering has been changed for the new 26ai DB version.
The major version remains the same (23), while the minor version matches the new database version. 

- Version 23.26.x.x.x maps to 26ai
- Version 23.27.x.x.x maps to 27ai if declared, otherwise falls back to 23ai
- The existing behavior for non-23+ versions remains unchanged
