### PR TITLE
HCK-13378: keep the property numberToCache empty on derive

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -161,17 +161,6 @@
 						}
 					}
 				]
-			],
-			[
-				"addPropertiesByPath",
-				[
-					{
-						"keyPath": "generatedDefaultValue.identity",
-						"subProperties": {
-							"numberToCache": 1
-						}
-					}
-				]
 			]
 		]
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13378" title="HCK-13378" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-13378</a>  Oracle: identity cache is added on derive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Right now when we derive numeric fields with autoincrement we add the `"numberToCache": 1`. It looks like it is not required and not expected, especially when user converts the model with auto-derive.