### PR TITLE
HCK-14582: fix the composite partitions configurations

### DIFF
--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -112,7 +112,6 @@ making sure that you maintain a proper JSON format.
 			}
 
 */
-
 [
 	{
 		"lowerTab": "Details",
@@ -706,7 +705,9 @@ making sure that you maintain a proper JSON format.
 					{
 						"propertyName": "Subpartition description",
 						"propertyKeyword": "subpartitionDescription",
-						"propertyType": "text",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false,
 						"propertyTooltip": "Specify subpartitions description. How many subpartitions you need and where you store them",
 						"dependency": {
 							"key": "partitionBy",
@@ -714,6 +715,7 @@ making sure that you maintain a proper JSON format.
 						}
 					},
 					{
+						// Although it is called "range_subpartition_descs" it actually represent "range_partition_desc" from documentation
 						"propertyName": "Range subpart desc",
 						"propertyType": "group",
 						"propertyKeyword": "range_subpartition_descs",
@@ -743,6 +745,7 @@ making sure that you maintain a proper JSON format.
 						}
 					},
 					{
+						// Although it is called "list_subpartition_descs" it actually represent "list_partition_desc" from documentation
 						"propertyName": "List subpart desc",
 						"propertyType": "group",
 						"propertyKeyword": "list_subpartition_descs",
@@ -758,8 +761,17 @@ making sure that you maintain a proper JSON format.
 							}
 						],
 						"dependency": {
-							"key": "subpartitionType",
-							"value": ["list", "hash", "range"]
+							"type": "and",
+							"values": [
+								{
+									"key": "partitionBy",
+									"value": ["composite list"]
+								},
+								{
+									"key": "subpartitionType",
+									"value": ["range", "hash", "list"]
+								}
+							]
 						}
 					},
 					{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14582" title="HCK-14582" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-14582</a>  Ensure subpartitions are fully handled in RE and FE of Oracle model
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

From what I understand the `subpartitionDescription` property is responsible for [subpartition_template](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/CREATE-TABLE.html#GUID-F9CE0CC3-13AE-4744-A43C-EAC7A71AAAB6__I2129934) or [SUBPARTITIONS integer ...](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/CREATE-TABLE.html#GUID-F9CE0CC3-13AE-4744-A43C-EAC7A71AAAB6__I2129906). So it should have a proper text editor.

I don't get why `range_subpartition_descs` and `list_subpartition_descs` are called this way, because they represent [range_partition_desc](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/CREATE-TABLE.html#GUID-F9CE0CC3-13AE-4744-A43C-EAC7A71AAAB6__BABEGHJB) and [list_partition_desc](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/CREATE-TABLE.html#GUID-F9CE0CC3-13AE-4744-A43C-EAC7A71AAAB6__BABIBDHH) of composite partitions, but I decided to not change that to avoid adding the adapter and breaking the compatibility between versions.