### PR TITLE
HCK-14796 Allow overriding constraint names (PK/NN) on attributes referencing definitions

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -2871,6 +2871,41 @@ making sure that you maintain a proper JSON format.
 				"defaultValue": false
 			},
 			{
+				"propertyName": "Not null constraint name",
+				"propertyKeyword": "notNullConstraintName",
+				"propertyType": "text",
+				"enableForReference": true,
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "required",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": [
+								{
+									"type": "and",
+									"values": [
+										{
+											"level": "root",
+											"key": "viewOn",
+											"exist": true
+										},
+										{
+											"level": "root",
+											"key": "duality",
+											"value": true
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			},
+			{
 				"propertyName": "Masked with function",
 				"propertyKeyword": "maskedWithFunction",
 				"propertyTooltip": "Limit exposure of sensitive data with this function",
@@ -4750,6 +4785,41 @@ making sure that you maintain a proper JSON format.
 				"defaultValue": false
 			},
 			{
+				"propertyName": "Not null constraint name",
+				"propertyKeyword": "notNullConstraintName",
+				"propertyType": "text",
+				"enableForReference": true,
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "required",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": [
+								{
+									"type": "and",
+									"values": [
+										{
+											"level": "root",
+											"key": "viewOn",
+											"exist": true
+										},
+										{
+											"level": "root",
+											"key": "duality",
+											"value": true
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			},
+			{
 				"propertyName": "Masked with function",
 				"propertyKeyword": "maskedWithFunction",
 				"propertyTooltip": "Limit exposure of sensitive data with this function",
@@ -6324,6 +6394,41 @@ making sure that you maintain a proper JSON format.
 				}
 			},
 			{
+				"propertyName": "Not null constraint name",
+				"propertyKeyword": "notNullConstraintName",
+				"propertyType": "text",
+				"enableForReference": true,
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "required",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": [
+								{
+									"type": "and",
+									"values": [
+										{
+											"level": "root",
+											"key": "viewOn",
+											"exist": true
+										},
+										{
+											"level": "root",
+											"key": "duality",
+											"value": true
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			},
+			{
 				"propertyName": "JSON key",
 				"propertyKeyword": "name",
 				"shouldValidate": true,
@@ -7231,6 +7336,41 @@ making sure that you maintain a proper JSON format.
 									"level": "root",
 									"key": "duality",
 									"value": true
+								}
+							]
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "Not null constraint name",
+				"propertyKeyword": "notNullConstraintName",
+				"propertyType": "text",
+				"enableForReference": true,
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "required",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": [
+								{
+									"type": "and",
+									"values": [
+										{
+											"level": "root",
+											"key": "viewOn",
+											"exist": true
+										},
+										{
+											"level": "root",
+											"key": "duality",
+											"value": true
+										}
+									]
 								}
 							]
 						}
@@ -8225,6 +8365,41 @@ making sure that you maintain a proper JSON format.
 					]
 				},
 				"defaultValue": false
+			},
+			{
+				"propertyName": "Not null constraint name",
+				"propertyKeyword": "notNullConstraintName",
+				"propertyType": "text",
+				"enableForReference": true,
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "required",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": [
+								{
+									"type": "and",
+									"values": [
+										{
+											"level": "root",
+											"key": "viewOn",
+											"exist": true
+										},
+										{
+											"level": "root",
+											"key": "duality",
+											"value": true
+										}
+									]
+								}
+							]
+						}
+					]
+				}
 			},
 			{
 				"propertyName": "Masked with function",
@@ -9535,6 +9710,41 @@ making sure that you maintain a proper JSON format.
 				"defaultValue": false
 			},
 			{
+				"propertyName": "Not null constraint name",
+				"propertyKeyword": "notNullConstraintName",
+				"propertyType": "text",
+				"enableForReference": true,
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "required",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": [
+								{
+									"type": "and",
+									"values": [
+										{
+											"level": "root",
+											"key": "viewOn",
+											"exist": true
+										},
+										{
+											"level": "root",
+											"key": "duality",
+											"value": true
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			},
+			{
 				"propertyName": "Row GUID Column",
 				"propertyKeyword": "ROWGUIDCOL",
 				"propertyType": "checkbox",
@@ -10717,6 +10927,41 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "required",
 				"propertyType": "checkbox"
 			},
+			{
+				"propertyName": "Not null constraint name",
+				"propertyKeyword": "notNullConstraintName",
+				"propertyType": "text",
+				"enableForReference": true,
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "required",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": [
+								{
+									"type": "and",
+									"values": [
+										{
+											"level": "root",
+											"key": "viewOn",
+											"exist": true
+										},
+										{
+											"level": "root",
+											"key": "duality",
+											"value": true
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			},
 			"minItems",
 			"maxItems",
 			"uniqueItems",
@@ -11480,6 +11725,41 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Not null",
 				"propertyKeyword": "required",
 				"propertyType": "checkbox"
+			},
+			{
+				"propertyName": "Not null constraint name",
+				"propertyKeyword": "notNullConstraintName",
+				"propertyType": "text",
+				"enableForReference": true,
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "required",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": [
+								{
+									"type": "and",
+									"values": [
+										{
+											"level": "root",
+											"key": "viewOn",
+											"exist": true
+										},
+										{
+											"level": "root",
+											"key": "duality",
+											"value": true
+										}
+									]
+								}
+							]
+						}
+					]
+				}
 			},
 			{
 				"propertyName": "Comments",
@@ -12460,6 +12740,41 @@ making sure that you maintain a proper JSON format.
 									"level": "root",
 									"key": "duality",
 									"value": true
+								}
+							]
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "Not null constraint name",
+				"propertyKeyword": "notNullConstraintName",
+				"propertyType": "text",
+				"enableForReference": true,
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "required",
+							"value": true
+						},
+						{
+							"type": "not",
+							"values": [
+								{
+									"type": "and",
+									"values": [
+										{
+											"level": "root",
+											"key": "viewOn",
+											"exist": true
+										},
+										{
+											"level": "root",
+											"key": "duality",
+											"value": true
+										}
+									]
 								}
 							]
 						}

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -940,6 +940,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Not null constraint name",
 				"propertyKeyword": "notNullConstraintName",
 				"propertyType": "text",
+				"enableForReference": true,
 				"dependency": {
 					"type": "and",
 					"values": [
@@ -1143,6 +1144,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Primary key",
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
+				"enableForReference": true,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
 					"type": "and",
@@ -2014,6 +2016,7 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
 				"defaultValue": false,
+				"enableForReference": true,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
 					"type": "and",
@@ -2997,6 +3000,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Primary key",
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
+				"enableForReference": true,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
 					"type": "and",
@@ -4009,6 +4013,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Key",
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
+				"enableForReference": true,
 				"defaultValue": false,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
@@ -4909,6 +4914,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Primary key",
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
+				"enableForReference": true,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
 					"type": "and",
@@ -5715,6 +5721,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Key",
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
+				"enableForReference": true,
 				"defaultValue": false,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
@@ -6465,6 +6472,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Key",
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
+				"enableForReference": true,
 				"defaultValue": false,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
@@ -7598,6 +7606,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Key",
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
+				"enableForReference": true,
 				"defaultValue": false,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
@@ -8347,6 +8356,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Primary key",
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
+				"enableForReference": true,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
 					"type": "and",
@@ -8965,6 +8975,7 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
 				"defaultValue": false,
+				"enableForReference": true,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
 					"type": "and",
@@ -9650,6 +9661,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Primary key",
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
+				"enableForReference": true,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
 					"type": "and",
@@ -10555,6 +10567,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Key",
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
+				"enableForReference": true,
 				"defaultValue": false,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
@@ -10870,6 +10883,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Primary key",
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
+				"enableForReference": true,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
 					"type": "and",
@@ -11947,6 +11961,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "Key",
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
+				"enableForReference": true,
 				"defaultValue": false,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
@@ -12655,6 +12670,7 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "primaryKey",
 				"propertyType": "checkbox",
 				"defaultValue": false,
+				"enableForReference": true,
 				"preserveOnCleanDependencies": true,
 				"dependency": {
 					"type": "and",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14796" title="HCK-14796" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-14796</a>  [Fidelity][Oracle] Allow overriding constraint names (PK/NN) on attributes referencing definitions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR improves constraint handling for Oracle when attributes reference definitions.

Changes included:
	•	Allow overriding the NOT NULL constraint name at attribute level for referenced definitions.
	•	Allow editing the Primary Key flag (yes/no) on attributes referencing definitions.
	•	Extend support for named NOT NULL constraints to all applicable data types (previously implemented only for CHAR).

Jira https://hackolade.atlassian.net/browse/HCK-14796