### PR TITLE
HCK-14858: Custom scripts in ALTER statements

### DIFF
--- a/forward_engineering/alterScript/alterScriptBuilder.js
+++ b/forward_engineering/alterScript/alterScriptBuilder.js
@@ -6,31 +6,27 @@ const { commentIfDeactivated } = require('../utils/general');
  * @return {(dtos: AlterScriptDto[], shouldApplyDropStatements: boolean) => string}
  * */
 const joinAlterScriptDtosIntoScript = (dtos, shouldApplyDropStatements) => {
-	return dtos
-		.map(dto => {
-			if (dto.isActivated === false) {
-				return dto.scripts.map(scriptDto =>
-					commentIfDeactivated(scriptDto.script, {
-						isActivated: false,
-						isPartOfLine: false,
-					}),
-				);
-			}
-			if (!shouldApplyDropStatements) {
-				return dto.scripts.map(scriptDto =>
-					commentIfDeactivated(scriptDto.script, {
-						isActivated: !scriptDto.isDropScript,
-						isPartOfLine: false,
-					}),
-				);
-			}
-			return dto.scripts.map(scriptDto => scriptDto.script);
-		})
-		.flat()
-		.filter(Boolean)
-		.map(scriptLine => scriptLine.trim())
-		.filter(Boolean)
-		.join('\n\n');
+	return dtos.reduce((finalScript, dto) => {
+		if (!dto) {
+			return finalScript;
+		}
+
+		let script = dto.script;
+
+		if (dto.isActivated === false) {
+			script = commentIfDeactivated(script, {
+				isActivated: false,
+				isPartOfLine: false,
+			});
+		} else if (!shouldApplyDropStatements) {
+			script = commentIfDeactivated(script, {
+				isActivated: !dto.isDropScript,
+				isPartOfLine: false,
+			});
+		}
+
+		return `${finalScript}\n\n${script}`;
+	}, '');
 };
 
 /**
@@ -54,11 +50,7 @@ const buildEntityLevelAlterScript = (data, app) => {
  * */
 const doesEntityLevelAlterScriptContainDropStatements = (data, app) => {
 	const alterScriptDtos = getAlterScriptDtos(data, app);
-	return alterScriptDtos.some(
-		alterScriptDto =>
-			alterScriptDto.isActivated &&
-			alterScriptDto.scripts.some(scriptModificationDto => scriptModificationDto.isDropScript),
-	);
+	return alterScriptDtos.some(alterScriptDto => alterScriptDto?.isActivated && alterScriptDto.isDropScript);
 };
 
 const mapCoreDataForContainerLevelScripts = data => {
@@ -92,11 +84,7 @@ const buildContainerLevelAlterScript = (data, app) => {
 const doesContainerLevelAlterScriptContainDropStatements = (data, app) => {
 	const preparedData = mapCoreDataForContainerLevelScripts(data);
 	const alterScriptDtos = getAlterScriptDtos(preparedData, app);
-	return alterScriptDtos.some(
-		alterScriptDto =>
-			alterScriptDto.isActivated &&
-			alterScriptDto.scripts.some(scriptModificationDto => scriptModificationDto.isDropScript),
-	);
+	return alterScriptDtos.some(alterScriptDto => alterScriptDto?.isActivated && alterScriptDto.isDropScript);
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptBuilder.js
+++ b/forward_engineering/alterScript/alterScriptBuilder.js
@@ -3,28 +3,47 @@ const { AlterScriptDto } = require('./types/AlterScriptDto');
 const { commentIfDeactivated } = require('../utils/general');
 
 /**
- * @return {(dtos: AlterScriptDto[], shouldApplyDropStatements: boolean) => string}
+ * @param {AlterScriptDto} dtos
+ * @param {boolean} shouldApplyDropStatements
+ * @return {AlterScriptDto}
+ * */
+const commentDto = (dto, shouldApplyDropStatements) => {
+	let script = dto.script;
+	const shouldDeactivate = dto.isActivated === false || (!shouldApplyDropStatements && dto.isDropScript);
+	if (shouldDeactivate) {
+		script = commentIfDeactivated(script, {
+			isActivated: false,
+			isPartOfLine: false,
+		});
+	}
+	return { ...dto, script };
+};
+
+/**
+ * @param {AlterScriptDto[]} dtos
+ * @param {boolean} shouldApplyDropStatements
+ * @return {AlterScriptDto[]}
+ * */
+const commentDtosIfRequired = (dtos, shouldApplyDropStatements) => {
+	return dtos.reduce((finalDtos, dto) => {
+		if (!dto) {
+			return finalDtos;
+		}
+		return [...finalDtos, commentDto(dto, shouldApplyDropStatements)];
+	}, []);
+};
+
+/**
+ * @param {AlterScriptDto[]} dtos
+ * @param {boolean} shouldApplyDropStatements
+ * @return {string}
  * */
 const joinAlterScriptDtosIntoScript = (dtos, shouldApplyDropStatements) => {
 	return dtos.reduce((finalScript, dto) => {
 		if (!dto) {
 			return finalScript;
 		}
-
-		let script = dto.script;
-
-		if (dto.isActivated === false) {
-			script = commentIfDeactivated(script, {
-				isActivated: false,
-				isPartOfLine: false,
-			});
-		} else if (!shouldApplyDropStatements) {
-			script = commentIfDeactivated(script, {
-				isActivated: !dto.isDropScript,
-				isPartOfLine: false,
-			});
-		}
-
+		const { script } = commentDto(dto, shouldApplyDropStatements);
 		return `${finalScript}\n\n${script}`;
 	}, '');
 };
@@ -40,7 +59,9 @@ const buildEntityLevelAlterScript = (data, app) => {
 		option => option.id === 'applyDropStatements' && option.value,
 	);
 
-	return joinAlterScriptDtosIntoScript(alterScriptDtos, shouldApplyDropStatements);
+	return data.options?.keepDtos
+		? commentDtosIfRequired(alterScriptDtos, shouldApplyDropStatements)
+		: joinAlterScriptDtosIntoScript(alterScriptDtos, shouldApplyDropStatements);
 };
 
 /**
@@ -73,7 +94,9 @@ const buildContainerLevelAlterScript = (data, app) => {
 		option => option.id === 'applyDropStatements' && option.value,
 	);
 
-	return joinAlterScriptDtosIntoScript(alterScriptDtos, shouldApplyDropStatements);
+	return preparedData.options?.keepDtos
+		? commentDtosIfRequired(alterScriptDtos, shouldApplyDropStatements)
+		: joinAlterScriptDtosIntoScript(alterScriptDtos, shouldApplyDropStatements);
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -51,12 +51,12 @@ const getAlterContainersScriptDtos = ({ collection, app, scriptFormat }) => {
 	const deletedContainers = getItems(containersData?.deleted);
 
 	const addContainersScriptDtos = addedContainers.map(container => {
-		const containerName = Object.keys(container.properties)[0];
-		return getAddContainerScriptDto(app, scriptFormat)(containerName);
+		const [[containerName, containerData]] = Object.entries(container.properties);
+		return getAddContainerScriptDto(app, scriptFormat)(containerName, containerData);
 	});
 	const deleteContainersScriptDtos = deletedContainers.map(container => {
-		const containerName = Object.keys(container.properties)[0];
-		return getDeleteContainerScriptDto(app, scriptFormat)(containerName);
+		const [[containerName, containerData]] = Object.entries(container.properties);
+		return getDeleteContainerScriptDto(app, scriptFormat)(containerName, containerData);
 	});
 
 	return [...addContainersScriptDtos, ...deleteContainersScriptDtos].filter(Boolean);

--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -34,6 +34,9 @@ const {
 	getAddContainerSequencesScriptDtos,
 } = require('./alterScriptHelpers/containerHelpers/alterSequenceHelper');
 
+const getItems = data => [data?.items].flat().filter(Boolean);
+const getItemProperties = data => getItems(data).map(item => Object.values(item.properties)[0]);
+
 /**
  * @param dto {{
  *     collection: Object,
@@ -43,17 +46,18 @@ const {
  * @return {AlterScriptDto[]}
  * */
 const getAlterContainersScriptDtos = ({ collection, app, scriptFormat }) => {
-	const addedContainers = collection.properties?.containers?.properties?.added?.items;
-	const deletedContainers = collection.properties?.containers?.properties?.deleted?.items;
+	const containersData = collection.properties?.containers?.properties;
+	const addedContainers = getItems(containersData?.added);
+	const deletedContainers = getItems(containersData?.deleted);
 
-	const addContainersScriptDtos = []
-		.concat(addedContainers)
-		.filter(Boolean)
-		.map(container => getAddContainerScriptDto(app, scriptFormat)(Object.keys(container.properties)[0]));
-	const deleteContainersScriptDtos = []
-		.concat(deletedContainers)
-		.filter(Boolean)
-		.map(container => getDeleteContainerScriptDto(app, scriptFormat)(Object.keys(container.properties)[0]));
+	const addContainersScriptDtos = addedContainers.map(container => {
+		const containerName = Object.keys(container.properties)[0];
+		return getAddContainerScriptDto(app, scriptFormat)(containerName);
+	});
+	const deleteContainersScriptDtos = deletedContainers.map(container => {
+		const containerName = Object.keys(container.properties)[0];
+		return getDeleteContainerScriptDto(app, scriptFormat)(containerName);
+	});
 
 	return [...addContainersScriptDtos, ...deleteContainersScriptDtos].filter(Boolean);
 };
@@ -131,20 +135,10 @@ const getAlterCollectionsScriptDtos = ({
 	scriptFormat,
 	inlineDeltaRelationships = [],
 }) => {
-	const createScriptsData = []
-		.concat(collection.properties?.entities?.properties?.added?.items)
-		.filter(Boolean)
-		.map(item => Object.values(item.properties)[0]);
-
-	const deleteScriptsData = []
-		.concat(collection.properties?.entities?.properties?.deleted?.items)
-		.filter(Boolean)
-		.map(item => Object.values(item.properties)[0]);
-
-	const modifyScriptsData = []
-		.concat(collection.properties?.entities?.properties?.modified?.items)
-		.filter(Boolean)
-		.map(item => Object.values(item.properties)[0]);
+	const collections = collection.properties?.entities?.properties;
+	const createScriptsData = getItemProperties(collections?.added);
+	const deleteScriptsData = getItemProperties(collections?.deleted);
+	const modifyScriptsData = getItemProperties(collections?.modified);
 
 	const createCollectionsScriptDtos = sortCollectionsByRelationships(
 		createScriptsData.filter(collection => collection.compMod?.created),
@@ -280,11 +274,13 @@ const getAlterModelDefinitionsScriptDtos = ({
 	externalDefinitions,
 	scriptFormat,
 }) => {
-	const createUdtScriptDtos = []
-		.concat(collection.properties?.modelDefinitions?.properties?.added?.items)
-		.filter(Boolean)
-		.map(item => Object.values(item.properties)[0])
-		.map(item => ({ ...item, ...(_.omit(item.role, 'properties') || {}) }))
+	const definitions = collection.properties?.modelDefinitions?.properties;
+	const addedDefinitions = getItemProperties(definitions?.added);
+	const deletedDefinitions = getItemProperties(definitions?.deleted);
+	const modifiedDefinitions = getItemProperties(definitions?.modified);
+
+	const createUdtScriptDtos = addedDefinitions
+		.map(item => ({ ...item, ..._.omit(item.role, 'properties') }))
 		.filter(item => item.compMod?.created)
 		.map(
 			getCreateUdtScriptDto({
@@ -296,19 +292,15 @@ const getAlterModelDefinitionsScriptDtos = ({
 				scriptFormat,
 			}),
 		);
-	const deleteUdtScriptDtos = []
-		.concat(collection.properties?.modelDefinitions?.properties?.deleted?.items)
-		.filter(Boolean)
-		.map(item => Object.values(item.properties)[0])
-		.map(item => ({ ...item, ...(_.omit(item.role, 'properties') || {}) }))
+
+	const deleteUdtScriptDtos = deletedDefinitions
+		.map(item => ({ ...item, ..._.omit(item.role, 'properties') }))
 		.filter(collection => collection.compMod?.deleted)
 		.map(getDeleteUdtScriptDto(app, scriptFormat));
-	const addColumnScriptDtos = []
-		.concat(collection.properties?.modelDefinitions?.properties?.added?.items)
-		.filter(Boolean)
-		.map(item => Object.values(item.properties)[0])
+
+	const addColumnScriptDtos = addedDefinitions
 		.filter(item => !item.compMod)
-		.map(item => ({ ...item, ...(_.omit(item.role, 'properties') || {}) }))
+		.map(item => ({ ...item, ..._.omit(item.role, 'properties') }))
 		.filter(item => item.childType === 'object_udt')
 		.flatMap(
 			getAddColumnToTypeScriptDtos({
@@ -320,21 +312,16 @@ const getAlterModelDefinitionsScriptDtos = ({
 				scriptFormat,
 			}),
 		);
-	const deleteColumnScriptDtos = []
-		.concat(collection.properties?.modelDefinitions?.properties?.deleted?.items)
-		.filter(Boolean)
-		.map(item => Object.values(item.properties)[0])
+
+	const deleteColumnScriptDtos = deletedDefinitions
 		.filter(item => !item.compMod)
-		.map(item => ({ ...item, ...(_.omit(item.role, 'properties') || {}) }))
+		.map(item => ({ ...item, ..._.omit(item.role, 'properties') }))
 		.filter(item => item.childType === 'object_udt')
 		.flatMap(getDeleteColumnFromTypeScriptDtos(app, scriptFormat));
 
-	const modifyColumnScriptDtos = []
-		.concat(collection.properties?.modelDefinitions?.properties?.modified?.items)
-		.filter(Boolean)
-		.map(item => Object.values(item.properties)[0])
+	const modifyColumnScriptDtos = modifiedDefinitions
 		.filter(item => !item.compMod)
-		.map(item => ({ ...item, ...(_.omit(item.role, 'properties') || {}) }))
+		.map(item => ({ ...item, ..._.omit(item.role, 'properties') }))
 		.filter(item => item.childType === 'object_udt')
 		.flatMap(getModifyColumnOfTypeScriptDtos(app, scriptFormat));
 
@@ -357,32 +344,20 @@ const getAlterRelationshipsScriptDtos = ({ collection, app, scriptFormat, ignore
 		app,
 	);
 
-	const addedRelationships = []
-		.concat(collection.properties?.relationships?.properties?.added?.items)
-		.filter(Boolean)
-		.map(item => Object.values(item.properties)[0])
-		.filter(
-			relationship =>
-				relationship?.role?.compMod?.created && !ignoreRelationshipIDs.includes(relationship?.role?.id),
-		);
+	const relationships = collection.properties?.relationships?.properties;
 
-	const deletedRelationships = []
-		.concat(collection.properties?.relationships?.properties?.deleted?.items)
-		.filter(Boolean)
-		.map(item => Object.values(item.properties)[0])
-		.filter(
-			relationship =>
-				relationship?.role?.compMod?.deleted && !ignoreRelationshipIDs.includes(relationship?.role?.id),
-		);
+	const addedRelationships = getItemProperties(relationships?.added).filter(
+		relationship => relationship?.role?.compMod?.created && !ignoreRelationshipIDs.includes(relationship?.role?.id),
+	);
 
-	const modifiedRelationships = []
-		.concat(collection.properties?.relationships?.properties?.modified?.items)
-		.filter(Boolean)
-		.map(item => Object.values(item.properties)[0])
-		.filter(
-			relationship =>
-				relationship?.role?.compMod?.modified && !ignoreRelationshipIDs.includes(relationship?.role?.id),
-		);
+	const deletedRelationships = getItemProperties(relationships?.deleted).filter(
+		relationship => relationship?.role?.compMod?.deleted && !ignoreRelationshipIDs.includes(relationship?.role?.id),
+	);
+
+	const modifiedRelationships = getItemProperties(relationships?.modified).filter(
+		relationship =>
+			relationship?.role?.compMod?.modified && !ignoreRelationshipIDs.includes(relationship?.role?.id),
+	);
 
 	const deleteFkScriptDtos = getDeleteForeignKeyScriptDtos(ddlProvider, scriptFormat)(deletedRelationships);
 	const addFkScriptDtos = getAddForeignKeyScriptDtos(ddlProvider)(addedRelationships);
@@ -426,25 +401,20 @@ const prettifyAlterScriptDto = dto => {
  * @return {AlterScriptDto[]}
  * */
 const getAlterContainersSequencesScriptDtos = ({ collection, app, dbVersion }) => {
-	const addedContainers = collection.properties?.containers?.properties?.added?.items;
-	const deletedContainers = collection.properties?.containers?.properties?.deleted?.items;
-	const modifiedContainers = collection.properties?.containers?.properties?.modified?.items;
+	const containers = collection.properties?.containers?.properties;
+	const addedContainers = getItemProperties(containers?.added);
+	const deletedContainers = getItemProperties(containers?.deleted);
+	const modifiedContainers = getItemProperties(containers?.modified);
 
-	const addContainersSequencesScriptDtos = []
-		.concat(addedContainers)
-		.filter(Boolean)
-		.map(container => Object.values(container.properties)[0])
-		.flatMap(container => getAddContainerSequencesScriptDtos({ app })({ container, dbVersion }));
-	const deleteContainersScriptDtos = []
-		.concat(deletedContainers)
-		.filter(Boolean)
-		.map(container => Object.values(container.properties)[0])
-		.flatMap(container => getDeleteContainerSequencesScriptDtos({ app })({ container, dbVersion }));
-	const modifyContainersScriptDtos = []
-		.concat(modifiedContainers)
-		.filter(Boolean)
-		.map(container => Object.values(container.properties)[0])
-		.flatMap(container => getModifyContainerSequencesScriptDtos({ app })({ container, dbVersion }));
+	const addContainersSequencesScriptDtos = addedContainers.map(container =>
+		getAddContainerSequencesScriptDtos({ app })({ container, dbVersion }),
+	);
+	const deleteContainersScriptDtos = deletedContainers.map(container =>
+		getDeleteContainerSequencesScriptDtos({ app })({ container, dbVersion }),
+	);
+	const modifyContainersScriptDtos = modifiedContainers.map(container =>
+		getModifyContainerSequencesScriptDtos({ app })({ container, dbVersion }),
+	);
 
 	return [...addContainersSequencesScriptDtos, ...deleteContainersScriptDtos, ...modifyContainersScriptDtos].filter(
 		Boolean,
@@ -456,13 +426,11 @@ const getInlineRelationships = ({ collection, options }) => {
 		return [];
 	}
 
-	const addedCollectionIDs = []
-		.concat(collection.properties?.entities?.properties?.added?.items)
+	const addedCollectionIDs = getItems(collection.properties?.entities?.properties?.added)
 		.filter(item => item && Object.values(item.properties)?.[0]?.compMod?.created)
 		.map(item => Object.values(item.properties)[0].role.id);
 
-	const addedRelationships = []
-		.concat(collection.properties?.relationships?.properties?.added?.items)
+	const addedRelationships = getItems(collection.properties?.relationships?.properties?.added)
 		.map(item => item && Object.values(item.properties)[0])
 		.filter(r => r?.role?.compMod?.created && addedCollectionIDs.includes(r?.role?.childCollection));
 

--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -406,13 +406,13 @@ const getAlterContainersSequencesScriptDtos = ({ collection, app, dbVersion }) =
 	const deletedContainers = getItemProperties(containers?.deleted);
 	const modifiedContainers = getItemProperties(containers?.modified);
 
-	const addContainersSequencesScriptDtos = addedContainers.map(container =>
+	const addContainersSequencesScriptDtos = addedContainers.flatMap(container =>
 		getAddContainerSequencesScriptDtos({ app })({ container, dbVersion }),
 	);
-	const deleteContainersScriptDtos = deletedContainers.map(container =>
+	const deleteContainersScriptDtos = deletedContainers.flatMap(container =>
 		getDeleteContainerSequencesScriptDtos({ app })({ container, dbVersion }),
 	);
-	const modifyContainersScriptDtos = modifiedContainers.map(container =>
+	const modifyContainersScriptDtos = modifiedContainers.flatMap(container =>
 		getModifyContainerSequencesScriptDtos({ app })({ container, dbVersion }),
 	);
 

--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -177,9 +177,7 @@ const getAlterCollectionsScriptDtos = ({
 		.flatMap(getDeleteColumnScriptDtos(app, scriptFormat));
 	const modifyColumnScriptDtos = modifyScriptsData.flatMap(getModifyColumnScriptDtos(app, dbVersion, scriptFormat));
 
-	const [collectionDropDtos, modifyCollectionDtos] = _.partition(modifyCollectionScriptDtos, collectionDto =>
-		collectionDto.scripts?.some(s => s.isDropScript),
-	);
+	const [collectionDropDtos, modifyCollectionDtos] = _.partition(modifyCollectionScriptDtos, dto => dto.isDropScript);
 
 	return [
 		...createCollectionsScriptDtos,
@@ -367,30 +365,6 @@ const getAlterRelationshipsScriptDtos = ({ collection, app, scriptFormat, ignore
 };
 
 /**
- * @param dto {AlterScriptDto}
- * @return {AlterScriptDto | undefined}
- */
-const prettifyAlterScriptDto = dto => {
-	if (!dto) {
-		return undefined;
-	}
-
-	const nonEmptyScriptModificationDtos = dto.scripts
-		.map(scriptDto => ({
-			...scriptDto,
-			script: (scriptDto.script || '').trim(),
-		}))
-		.filter(scriptDto => Boolean(scriptDto.script));
-	if (!nonEmptyScriptModificationDtos.length) {
-		return undefined;
-	}
-	return {
-		...dto,
-		scripts: nonEmptyScriptModificationDtos,
-	};
-};
-
-/**
  * @param {{
  * collection: Object,
  * app: App,
@@ -501,10 +475,7 @@ const getAlterScriptDtos = (data, app) => {
 		...collectionsScriptDtos,
 		...viewScriptDtos.restViewScripts,
 		...relationshipScriptDtos,
-	]
-		.filter(Boolean)
-		.map(dto => prettifyAlterScriptDto(dto))
-		.filter(Boolean);
+	].filter(Boolean);
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
+++ b/forward_engineering/alterScript/alterScriptFromDeltaHelper.js
@@ -25,7 +25,7 @@ const {
 	getDeleteForeignKeyScriptDtos,
 	getAddForeignKeyScriptDtos,
 } = require('./alterScriptHelpers/alterRelationshipsHelper');
-const { AlterScriptDto, ModificationScript } = require('./types/AlterScriptDto');
+const { AlterScriptDto } = require('./types/AlterScriptDto');
 const { App, CoreData } = require('../types/coreApplicationTypes');
 const { InternalDefinitions, ModelDefinitions, ExternalDefinitions } = require('../types/coreApplicationDataTypes');
 const {
@@ -143,7 +143,7 @@ const getAlterCollectionsScriptDtos = ({
 	const createCollectionsScriptDtos = sortCollectionsByRelationships(
 		createScriptsData.filter(collection => collection.compMod?.created),
 		inlineDeltaRelationships,
-	).map(
+	).flatMap(
 		getAddCollectionScriptDto({
 			app,
 			dbVersion,
@@ -374,9 +374,7 @@ const prettifyAlterScriptDto = dto => {
 	if (!dto) {
 		return undefined;
 	}
-	/**
-	 * @type {Array<ModificationScript>}
-	 * */
+
 	const nonEmptyScriptModificationDtos = dto.scripts
 		.map(scriptDto => ({
 			...scriptDto,

--- a/forward_engineering/alterScript/alterScriptHelpers/alterContainerHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterContainerHelper.js
@@ -1,24 +1,30 @@
-const { prepareNameForScriptFormat } = require('../../utils/general');
-const { AlterScriptDto } = require('../types/AlterScriptDto');
+const { prepareNameForScriptFormat, getId } = require('../../utils/general');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../types/AlterScriptDto');
 
 /**
  * @return {(containerName: string) => AlterScriptDto | undefined}
  * */
-const getAddContainerScriptDto = (app, scriptFormat) => containerName => {
+const getAddContainerScriptDto = (app, scriptFormat) => (containerName, jsonSchema) => {
 	const ddlContainerName = prepareNameForScriptFormat(scriptFormat)(containerName);
 
 	const createContainerStatement = `CREATE USER ${ddlContainerName} NO AUTHENTICATION;`;
-	return AlterScriptDto.getInstance(createContainerStatement, true, false);
+	return AlterScriptDto.getInstance(
+		createContainerStatement,
+		true,
+		false,
+		SCRIPT_TYPE.createContainer,
+		getId(jsonSchema),
+	);
 };
 
 /**
  * @return {(containerName: string) => AlterScriptDto | undefined}
  * */
-const getDeleteContainerScriptDto = (app, scriptFormat) => containerName => {
+const getDeleteContainerScriptDto = (app, scriptFormat) => (containerName, jsonSchema) => {
 	const ddlContainerName = prepareNameForScriptFormat(scriptFormat)(containerName);
 
 	const dropContainerStatement = `DROP USER ${ddlContainerName};`;
-	return AlterScriptDto.getInstance(dropContainerStatement, true, true);
+	return AlterScriptDto.getInstance(dropContainerStatement, true, true, SCRIPT_TYPE.dropContainer, getId(jsonSchema));
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/alterContainerHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterContainerHelper.js
@@ -8,7 +8,7 @@ const getAddContainerScriptDto = (app, scriptFormat) => containerName => {
 	const ddlContainerName = prepareNameForScriptFormat(scriptFormat)(containerName);
 
 	const createContainerStatement = `CREATE USER ${ddlContainerName} NO AUTHENTICATION;`;
-	return AlterScriptDto.getInstance([createContainerStatement], true, false);
+	return AlterScriptDto.getInstance(createContainerStatement, true, false);
 };
 
 /**
@@ -18,7 +18,7 @@ const getDeleteContainerScriptDto = (app, scriptFormat) => containerName => {
 	const ddlContainerName = prepareNameForScriptFormat(scriptFormat)(containerName);
 
 	const dropContainerStatement = `DROP USER ${ddlContainerName};`;
-	return AlterScriptDto.getInstance([dropContainerStatement], true, true);
+	return AlterScriptDto.getInstance(dropContainerStatement, true, true);
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -98,9 +98,11 @@ const getAddCollectionScriptDto =
 			ddlProvider,
 			collection,
 			dbVersion,
-		}).flatMap(({ scripts }) => scripts.map(({ script }) => script));
+		});
+
 		const script = ddlProvider.createTable(hydratedTable, jsonSchema.isActivated);
-		return AlterScriptDto.getInstance([script, ...indexesOnNewlyCreatedColumnsScripts], true, false);
+
+		return [AlterScriptDto.getInstance(script, true, false), ...indexesOnNewlyCreatedColumnsScripts];
 	};
 
 /**
@@ -113,7 +115,7 @@ const getDeleteCollectionScriptDto = (app, scriptFormat) => collection => {
 	const fullName = getNamePrefixedWithSchemaNameForScriptFormat(scriptFormat)(tableName, schemaName);
 
 	const script = `DROP TABLE ${fullName};`;
-	return AlterScriptDto.getInstance([script], true, true);
+	return AlterScriptDto.getInstance(script, true, true);
 };
 
 /**
@@ -184,12 +186,13 @@ const getAddColumnScriptDtos =
 					definitionJsonSchema,
 				});
 			})
-			.map(data => ddlProvider.convertColumnDefinition(data))
-			.map(script => `ALTER TABLE ${fullName} ADD (${script});`)
-			.map(script => AlterScriptDto.getInstance([script], true, false))
-			.filter(Boolean);
+			.map(data => {
+				const scriptPart = ddlProvider.convertColumnDefinition(data);
+				const script = `ALTER TABLE ${fullName} ADD (${scriptPart});`;
+				return AlterScriptDto.getInstance(script, true, false);
+			});
 
-		return scripts.filter(Boolean);
+		return scripts;
 	};
 
 /**
@@ -227,9 +230,10 @@ const getDeleteColumnScriptDtos = (app, scriptFormat) => collection => {
 
 	return _.toPairs(collection.properties)
 		.filter(([name, jsonSchema]) => !jsonSchema.compMod)
-		.map(([name]) => `ALTER TABLE ${fullName} DROP COLUMN ${prepareNameForScriptFormat(scriptFormat)(name)};`)
-		.map(script => AlterScriptDto.getInstance([script], true, true))
-		.filter(Boolean);
+		.map(([name]) => {
+			const script = `ALTER TABLE ${fullName} DROP COLUMN ${prepareNameForScriptFormat(scriptFormat)(name)};`;
+			return AlterScriptDto.getInstance(script, true, true);
+		});
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterEntityHelper.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../types/AlterScriptDto');
 const { AlterCollectionDto } = require('../types/AlterCollectionDto');
 const { getUpdateTypesScriptDtos } = require('./columnHelpers/alterTypeHelper');
 const { getRenameColumnScriptDtos } = require('./columnHelpers/renameColumnHelper');
@@ -8,6 +8,7 @@ const {
 	getEntityName,
 	getNamePrefixedWithSchemaNameForScriptFormat,
 	prepareNameForScriptFormat,
+	getId,
 } = require('../../utils/general');
 const { getModifyCheckConstraintScriptDtos } = require('./entityHelpers/checkConstraintHelper');
 const { getModifyPkConstraintsScriptDtos } = require('./entityHelpers/primaryKeyHelper');
@@ -102,20 +103,23 @@ const getAddCollectionScriptDto =
 
 		const script = ddlProvider.createTable(hydratedTable, jsonSchema.isActivated);
 
-		return [AlterScriptDto.getInstance(script, true, false), ...indexesOnNewlyCreatedColumnsScripts];
+		return [
+			AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.createEntity, getId(jsonSchema)),
+			...indexesOnNewlyCreatedColumnsScripts,
+		];
 	};
 
 /**
  * @return {(collection: AlterCollectionDto) => AlterScriptDto | undefined}
  * */
 const getDeleteCollectionScriptDto = (app, scriptFormat) => collection => {
-	const jsonData = { ...collection, ...(_.omit(collection?.role, 'properties') || {}) };
+	const jsonData = { ...collection, ..._.omit(collection?.role, 'properties') };
 	const tableName = getEntityName(jsonData);
 	const schemaName = collection.compMod.keyspaceName;
 	const fullName = getNamePrefixedWithSchemaNameForScriptFormat(scriptFormat)(tableName, schemaName);
 
 	const script = `DROP TABLE ${fullName};`;
-	return AlterScriptDto.getInstance(script, true, true);
+	return AlterScriptDto.getInstance(script, true, true, SCRIPT_TYPE.dropEntity, getId(jsonData));
 };
 
 /**
@@ -161,7 +165,7 @@ const getAddColumnScriptDtos =
 		);
 		const { getDefinitionByReference } = app.require('@hackolade/ddl-fe-utils');
 
-		const collectionSchema = { ...collection, ...(_.omit(collection?.role, 'properties') || {}) };
+		const collectionSchema = { ...collection, ..._.omit(collection?.role, 'properties') };
 		const tableName = getEntityName(collectionSchema);
 		const schemaName = collectionSchema.compMod?.keyspaceName;
 		const fullName = getNamePrefixedWithSchemaNameForScriptFormat(scriptFormat)(tableName, schemaName);
@@ -189,7 +193,13 @@ const getAddColumnScriptDtos =
 			.map(data => {
 				const scriptPart = ddlProvider.convertColumnDefinition(data);
 				const script = `ALTER TABLE ${fullName} ADD (${scriptPart});`;
-				return AlterScriptDto.getInstance(script, true, false);
+				return AlterScriptDto.getInstance(
+					script,
+					true,
+					false,
+					SCRIPT_TYPE.alterEntity,
+					getId(collectionSchema),
+				);
 			});
 
 		return scripts;
@@ -223,7 +233,7 @@ const getNewlyCreatedIndexesScripts = ({ ddlProvider, collection }) => {
  * @return {(collection: Object) => AlterScriptDto[]}
  * */
 const getDeleteColumnScriptDtos = (app, scriptFormat) => collection => {
-	const collectionSchema = { ...collection, ...(_.omit(collection?.role, 'properties') || {}) };
+	const collectionSchema = { ...collection, ..._.omit(collection?.role, 'properties') };
 	const tableName = getEntityName(collectionSchema);
 	const schemaName = collectionSchema.compMod?.keyspaceName;
 	const fullName = getNamePrefixedWithSchemaNameForScriptFormat(scriptFormat)(tableName, schemaName);
@@ -232,7 +242,7 @@ const getDeleteColumnScriptDtos = (app, scriptFormat) => collection => {
 		.filter(([name, jsonSchema]) => !jsonSchema.compMod)
 		.map(([name]) => {
 			const script = `ALTER TABLE ${fullName} DROP COLUMN ${prepareNameForScriptFormat(scriptFormat)(name)};`;
-			return AlterScriptDto.getInstance(script, true, true);
+			return AlterScriptDto.getInstance(script, true, true, SCRIPT_TYPE.alterEntity, getId(collectionSchema));
 		});
 };
 

--- a/forward_engineering/alterScript/alterScriptHelpers/alterRelationshipsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterRelationshipsHelper.js
@@ -63,7 +63,7 @@ const canRelationshipBeAdded = relationship => {
 		compMod.child?.bucket,
 		compMod.child?.collection,
 		compMod.child?.collection?.fkFields?.length,
-	].every(property => Boolean(property));
+	].every(Boolean);
 };
 
 /**
@@ -74,10 +74,9 @@ const getAddForeignKeyScriptDtos = ddlProvider => addedRelationships => {
 		.filter(relationship => canRelationshipBeAdded(relationship))
 		.map(relationship => {
 			const scriptDto = getAddSingleForeignKeyStatementDto(ddlProvider)(relationship);
-			return AlterScriptDto.getInstance([scriptDto.statement], scriptDto.isActivated, false);
+			return AlterScriptDto.getInstance(scriptDto.statement, scriptDto.isActivated, false);
 		})
-		.filter(Boolean)
-		.filter(res => res.scripts.some(scriptDto => Boolean(scriptDto.script)));
+		.filter(Boolean);
 };
 
 /**
@@ -116,7 +115,7 @@ const canRelationshipBeDeleted = relationship => {
 		compMod.code?.old || compMod.name?.old || getRelationshipName(relationship),
 		compMod.child?.bucket,
 		compMod.child?.collection,
-	].every(property => Boolean(property));
+	].every(Boolean);
 };
 
 /**
@@ -127,10 +126,9 @@ const getDeleteForeignKeyScriptDtos = (ddlProvider, scriptFormat) => deletedRela
 		.filter(relationship => canRelationshipBeDeleted(relationship))
 		.map(relationship => {
 			const scriptDto = getDeleteSingleForeignKeyStatementDto(ddlProvider, scriptFormat)(relationship);
-			return AlterScriptDto.getInstance([scriptDto.statement], scriptDto.isActivated, true);
+			return AlterScriptDto.getInstance(scriptDto.statement, scriptDto.isActivated, true);
 		})
-		.filter(Boolean)
-		.filter(res => res.scripts.some(scriptDto => Boolean(scriptDto.script)));
+		.filter(Boolean);
 };
 
 /**
@@ -139,18 +137,16 @@ const getDeleteForeignKeyScriptDtos = (ddlProvider, scriptFormat) => deletedRela
 const getModifyForeignKeyScriptDtos = (ddlProvider, scriptFormat) => modifiedRelationships => {
 	return modifiedRelationships
 		.filter(relationship => canRelationshipBeAdded(relationship) && canRelationshipBeDeleted(relationship))
-		.map(relationship => {
+		.flatMap(relationship => {
 			const deleteScriptDto = getDeleteSingleForeignKeyStatementDto(ddlProvider, scriptFormat)(relationship);
 			const addScriptDto = getAddSingleForeignKeyStatementDto(ddlProvider)(relationship);
 			const isActivated = addScriptDto.isActivated && deleteScriptDto.isActivated;
-			return AlterScriptDto.getDropAndRecreateInstance(
-				deleteScriptDto.statement,
-				addScriptDto.statement,
-				isActivated,
-			);
+			return [
+				AlterScriptDto.getInstance(deleteScriptDto.statement, isActivated, true),
+				AlterScriptDto.getInstance(addScriptDto.statement, isActivated, false),
+			];
 		})
-		.filter(Boolean)
-		.filter(res => res.scripts.some(scriptDto => Boolean(scriptDto.script)));
+		.filter(Boolean);
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/alterRelationshipsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterRelationshipsHelper.js
@@ -1,4 +1,4 @@
-const { AlterScriptDto } = require('../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../types/AlterScriptDto');
 const { AlterRelationshipDto } = require('../types/AlterRelationshipDto');
 const { getNamePrefixedWithSchemaNameForScriptFormat, prepareNameForScriptFormat } = require('../../utils/general');
 
@@ -74,7 +74,12 @@ const getAddForeignKeyScriptDtos = ddlProvider => addedRelationships => {
 		.filter(relationship => canRelationshipBeAdded(relationship))
 		.map(relationship => {
 			const scriptDto = getAddSingleForeignKeyStatementDto(ddlProvider)(relationship);
-			return AlterScriptDto.getInstance(scriptDto.statement, scriptDto.isActivated, false);
+			return AlterScriptDto.getInstance(
+				scriptDto.statement,
+				scriptDto.isActivated,
+				false,
+				SCRIPT_TYPE.alterEntity,
+			);
 		})
 		.filter(Boolean);
 };
@@ -126,7 +131,12 @@ const getDeleteForeignKeyScriptDtos = (ddlProvider, scriptFormat) => deletedRela
 		.filter(relationship => canRelationshipBeDeleted(relationship))
 		.map(relationship => {
 			const scriptDto = getDeleteSingleForeignKeyStatementDto(ddlProvider, scriptFormat)(relationship);
-			return AlterScriptDto.getInstance(scriptDto.statement, scriptDto.isActivated, true);
+			return AlterScriptDto.getInstance(
+				scriptDto.statement,
+				scriptDto.isActivated,
+				true,
+				SCRIPT_TYPE.alterEntity,
+			);
 		})
 		.filter(Boolean);
 };
@@ -142,8 +152,8 @@ const getModifyForeignKeyScriptDtos = (ddlProvider, scriptFormat) => modifiedRel
 			const addScriptDto = getAddSingleForeignKeyStatementDto(ddlProvider)(relationship);
 			const isActivated = addScriptDto.isActivated && deleteScriptDto.isActivated;
 			return [
-				AlterScriptDto.getInstance(deleteScriptDto.statement, isActivated, true),
-				AlterScriptDto.getInstance(addScriptDto.statement, isActivated, false),
+				AlterScriptDto.getInstance(deleteScriptDto.statement, isActivated, true, SCRIPT_TYPE.alterEntity),
+				AlterScriptDto.getInstance(addScriptDto.statement, isActivated, false, SCRIPT_TYPE.alterEntity),
 			];
 		})
 		.filter(Boolean);

--- a/forward_engineering/alterScript/alterScriptHelpers/alterUdtHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterUdtHelper.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const { checkFieldPropertiesChanged, prepareNameForScriptFormat } = require('../../utils/general');
 const templates = require('../../ddlProvider/templates');
-const { AlterScriptDto } = require('../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../types/AlterScriptDto');
 
 /**
  * @return {(jsonSchema: Object) => AlterScriptDto |  undefined}
@@ -48,7 +48,7 @@ const getCreateUdtScriptDto =
 
 		const udt = { ...updatedUdt, properties: columnDefinitions };
 		const script = ddlProvider.createUdt(udt);
-		return AlterScriptDto.getInstance(script, true, false);
+		return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.createUDT);
 	};
 
 /**
@@ -57,7 +57,7 @@ const getCreateUdtScriptDto =
 const getDeleteUdtScriptDto = (app, scriptFormat) => udt => {
 	const ddlUdtName = prepareNameForScriptFormat(scriptFormat)(udt.code || udt.name);
 	const dropUdtScript = `DROP TYPE ${ddlUdtName};`;
-	return AlterScriptDto.getInstance(dropUdtScript, true, true);
+	return AlterScriptDto.getInstance(dropUdtScript, true, true, SCRIPT_TYPE.dropUDT);
 };
 
 /**
@@ -99,7 +99,7 @@ const getAddColumnToTypeScriptDtos =
 			.map(data => {
 				const scriptPart = ddlProvider.convertColumnDefinition(data, templates.objectTypeColumnDefinition);
 				const script = `ALTER TYPE ${fullName} ADD ATTRIBUTE ${scriptPart};`;
-				return AlterScriptDto.getInstance(script, true, false);
+				return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.alterUDT);
 			});
 	};
 
@@ -113,7 +113,7 @@ const getDeleteColumnFromTypeScriptDtos = (app, scriptFormat) => udt => {
 		.filter(([name, jsonSchema]) => !jsonSchema.compMod)
 		.map(([name]) => {
 			const script = `ALTER TYPE ${fullName} DROP ATTRIBUTE ${prepareNameForScriptFormat(scriptFormat)(name)};`;
-			return AlterScriptDto.getInstance(script, true, true);
+			return AlterScriptDto.getInstance(script, true, true, SCRIPT_TYPE.alterUDT);
 		});
 };
 
@@ -136,8 +136,8 @@ const getModifyColumnOfTypeScriptDtos = (app, scriptFormat) => udt => {
 			const createAttributeScript = `ALTER TYPE ${fullName} ADD ATTRIBUTE ${newDdlName};`;
 
 			return [
-				AlterScriptDto.getInstance(dropAttributeScript, true, true),
-				AlterScriptDto.getInstance(createAttributeScript, true, false),
+				AlterScriptDto.getInstance(dropAttributeScript, true, true, SCRIPT_TYPE.alterUDT),
+				AlterScriptDto.getInstance(createAttributeScript, true, false, SCRIPT_TYPE.alterUDT),
 			];
 		});
 
@@ -150,7 +150,7 @@ const getModifyColumnOfTypeScriptDtos = (app, scriptFormat) => udt => {
 			const ddlAttributeName = prepareNameForScriptFormat(scriptFormat)(name);
 			const ddlType = _.toUpper(jsonSchema.compMod.newField.mode || jsonSchema.compMod.newField.type);
 			const script = `ALTER TYPE ${fullName} MODIFY ATTRIBUTE ${ddlAttributeName} ${ddlType};`;
-			return AlterScriptDto.getInstance(script, true, false);
+			return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.alterUDT);
 		});
 
 	return [...renameColumnScripts, ...changeTypeScripts];

--- a/forward_engineering/alterScript/alterScriptHelpers/alterUdtHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterUdtHelper.js
@@ -48,7 +48,7 @@ const getCreateUdtScriptDto =
 
 		const udt = { ...updatedUdt, properties: columnDefinitions };
 		const script = ddlProvider.createUdt(udt);
-		return AlterScriptDto.getInstance([script], true, false);
+		return AlterScriptDto.getInstance(script, true, false);
 	};
 
 /**
@@ -57,7 +57,7 @@ const getCreateUdtScriptDto =
 const getDeleteUdtScriptDto = (app, scriptFormat) => udt => {
 	const ddlUdtName = prepareNameForScriptFormat(scriptFormat)(udt.code || udt.name);
 	const dropUdtScript = `DROP TYPE ${ddlUdtName};`;
-	return AlterScriptDto.getInstance([dropUdtScript], true, true);
+	return AlterScriptDto.getInstance(dropUdtScript, true, true);
 };
 
 /**
@@ -96,9 +96,11 @@ const getAddColumnToTypeScriptDtos =
 					definitionJsonSchema,
 				});
 			})
-			.map(data => ddlProvider.convertColumnDefinition(data, templates.objectTypeColumnDefinition))
-			.map(script => `ALTER TYPE ${fullName} ADD ATTRIBUTE ${script};`)
-			.map(script => AlterScriptDto.getInstance([script], true, false));
+			.map(data => {
+				const scriptPart = ddlProvider.convertColumnDefinition(data, templates.objectTypeColumnDefinition);
+				const script = `ALTER TYPE ${fullName} ADD ATTRIBUTE ${scriptPart};`;
+				return AlterScriptDto.getInstance(script, true, false);
+			});
 	};
 
 /**
@@ -109,8 +111,10 @@ const getDeleteColumnFromTypeScriptDtos = (app, scriptFormat) => udt => {
 
 	return _.toPairs(udt.properties)
 		.filter(([name, jsonSchema]) => !jsonSchema.compMod)
-		.map(([name]) => `ALTER TYPE ${fullName} DROP ATTRIBUTE ${prepareNameForScriptFormat(scriptFormat)(name)};`)
-		.map(script => AlterScriptDto.getInstance([script], true, true));
+		.map(([name]) => {
+			const script = `ALTER TYPE ${fullName} DROP ATTRIBUTE ${prepareNameForScriptFormat(scriptFormat)(name)};`;
+			return AlterScriptDto.getInstance(script, true, true);
+		});
 };
 
 /**
@@ -132,8 +136,8 @@ const getModifyColumnOfTypeScriptDtos = (app, scriptFormat) => udt => {
 			const createAttributeScript = `ALTER TYPE ${fullName} ADD ATTRIBUTE ${newDdlName};`;
 
 			return [
-				AlterScriptDto.getInstance([dropAttributeScript], true, true),
-				AlterScriptDto.getInstance([createAttributeScript], true, false),
+				AlterScriptDto.getInstance(dropAttributeScript, true, true),
+				AlterScriptDto.getInstance(createAttributeScript, true, false),
 			];
 		});
 
@@ -146,7 +150,7 @@ const getModifyColumnOfTypeScriptDtos = (app, scriptFormat) => udt => {
 			const ddlAttributeName = prepareNameForScriptFormat(scriptFormat)(name);
 			const ddlType = _.toUpper(jsonSchema.compMod.newField.mode || jsonSchema.compMod.newField.type);
 			const script = `ALTER TYPE ${fullName} MODIFY ATTRIBUTE ${ddlAttributeName} ${ddlType};`;
-			return AlterScriptDto.getInstance([script], true, false);
+			return AlterScriptDto.getInstance(script, true, false);
 		});
 
 	return [...renameColumnScripts, ...changeTypeScripts];

--- a/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../types/AlterScriptDto');
 const { mapDeltaDualityViewToFeDualityView } = require('./dualityViewHelpers/deltaDualityViewToFeDualityViewMapper');
-const { prepareNameForScriptFormat } = require('../../utils/general');
+const { prepareNameForScriptFormat, getId } = require('../../utils/general');
 const { getModifyViewCommentsScriptDtos } = require('./viewHelpers/commentsHelper');
 const { getModifyEntityNameScriptDtos } = require('./viewHelpers/nameHelper');
 
@@ -26,7 +26,7 @@ const getAddRegularViewScriptDto = (app, scriptFormat) => view => {
 	};
 	const hydratedView = ddlProvider.hydrateView({ viewData, entityData: [view] });
 	const createViewStatement = ddlProvider.createView(hydratedView, {}, view.isActivated);
-	return AlterScriptDto.getInstance(createViewStatement, true, false);
+	return AlterScriptDto.getInstance(createViewStatement, true, false, SCRIPT_TYPE.createView, getId(view));
 };
 
 /**
@@ -41,7 +41,7 @@ const getDualityViewScriptDto = (app, scriptFormat) => view => {
 
 	const createDualityViewDto = mapDeltaDualityViewToFeDualityView(view);
 	const script = ddlProvider.createDualityView(createDualityViewDto);
-	return AlterScriptDto.getInstance(script, true, false);
+	return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.createView, getId(view));
 };
 
 /**
@@ -61,7 +61,7 @@ const getDeleteViewScriptDto = (app, scriptFormat) => view => {
 	const ddlViewName = prepareNameForScriptFormat(scriptFormat)(view.code || view.name);
 
 	const dropViewScript = `DROP VIEW ${ddlViewName};`;
-	return AlterScriptDto.getInstance(dropViewScript, true, true);
+	return AlterScriptDto.getInstance(dropViewScript, true, true, SCRIPT_TYPE.dropView, getId(view));
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/alterViewHelper.js
@@ -26,7 +26,7 @@ const getAddRegularViewScriptDto = (app, scriptFormat) => view => {
 	};
 	const hydratedView = ddlProvider.hydrateView({ viewData, entityData: [view] });
 	const createViewStatement = ddlProvider.createView(hydratedView, {}, view.isActivated);
-	return AlterScriptDto.getInstance([createViewStatement], true, false);
+	return AlterScriptDto.getInstance(createViewStatement, true, false);
 };
 
 /**
@@ -41,7 +41,7 @@ const getDualityViewScriptDto = (app, scriptFormat) => view => {
 
 	const createDualityViewDto = mapDeltaDualityViewToFeDualityView(view);
 	const script = ddlProvider.createDualityView(createDualityViewDto);
-	return AlterScriptDto.getInstance([script], true, false);
+	return AlterScriptDto.getInstance(script, true, false);
 };
 
 /**
@@ -61,7 +61,7 @@ const getDeleteViewScriptDto = (app, scriptFormat) => view => {
 	const ddlViewName = prepareNameForScriptFormat(scriptFormat)(view.code || view.name);
 
 	const dropViewScript = `DROP VIEW ${ddlViewName};`;
-	return AlterScriptDto.getInstance([dropViewScript], true, true);
+	return AlterScriptDto.getInstance(dropViewScript, true, true);
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/alterTypeHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/alterTypeHelper.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	checkFieldPropertiesChanged,
 	prepareNameForScriptFormat,
@@ -93,7 +93,7 @@ const getUpdateTypesScriptDtos = (ddlProvider, scriptFormat) => collection => {
 			const type = _.toUpper(jsonSchema.compMod.newField.mode || jsonSchema.compMod.newField.type);
 			const columnName = prepareNameForScriptFormat(scriptFormat)(name);
 			const script = alterColumnType(fullName, columnName, type, jsonSchema);
-			return AlterScriptDto.getInstance(script, true, true);
+			return AlterScriptDto.getInstance(script, true, true, SCRIPT_TYPE.alterEntity);
 		});
 };
 

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/alterTypeHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/alterTypeHelper.js
@@ -92,9 +92,9 @@ const getUpdateTypesScriptDtos = (ddlProvider, scriptFormat) => collection => {
 		.map(([name, jsonSchema]) => {
 			const type = _.toUpper(jsonSchema.compMod.newField.mode || jsonSchema.compMod.newField.type);
 			const columnName = prepareNameForScriptFormat(scriptFormat)(name);
-			return alterColumnType(fullName, columnName, type, jsonSchema);
-		})
-		.map(script => AlterScriptDto.getInstance([script], true, true));
+			const script = alterColumnType(fullName, columnName, type, jsonSchema);
+			return AlterScriptDto.getInstance(script, true, true);
+		});
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/commentsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/commentsHelper.js
@@ -48,9 +48,9 @@ const getUpdatedCommentOnColumnScriptDtos = ({ scriptFormat, collection }) => {
 			const columnName = prepareNameForScriptFormat(scriptFormat)(name);
 			const fullColumnName = `${fullTableName}.${columnName}`;
 
-			return updateColumnComment(fullColumnName, wrappedComment);
-		})
-		.map(script => AlterScriptDto.getInstance([script], true, false));
+			const script = updateColumnComment(fullColumnName, wrappedComment);
+			return AlterScriptDto.getInstance(script, true, false);
+		});
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/commentsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/commentsHelper.js
@@ -1,5 +1,5 @@
 const { toPairs } = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	getFullColumnName,
 	wrapComment,
@@ -49,7 +49,7 @@ const getUpdatedCommentOnColumnScriptDtos = ({ scriptFormat, collection }) => {
 			const fullColumnName = `${fullTableName}.${columnName}`;
 
 			const script = updateColumnComment(fullColumnName, wrappedComment);
-			return AlterScriptDto.getInstance(script, true, false);
+			return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.alterEntity);
 		});
 };
 

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/defaultValueHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/defaultValueHelper.js
@@ -51,9 +51,9 @@ const getUpdatedDefaultColumnValueScriptDtos = ({ scriptFormat, collection }) =>
 				defaultValue: getColumnDefault(jsonSchema),
 			};
 
-			return updateColumnDefaultValue(scriptGenerationConfig);
+			const script = updateColumnDefaultValue(scriptGenerationConfig);
+			return AlterScriptDto.getInstance(script, true, false);
 		})
-		.map(script => AlterScriptDto.getInstance([script], true, false))
 		.filter(Boolean);
 };
 

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/defaultValueHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/defaultValueHelper.js
@@ -1,5 +1,5 @@
 const { toPairs } = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const { AlterCollectionDto } = require('../../types/AlterCollectionDto');
 const {
 	prepareNameForScriptFormat,
@@ -52,7 +52,7 @@ const getUpdatedDefaultColumnValueScriptDtos = ({ scriptFormat, collection }) =>
 			};
 
 			const script = updateColumnDefaultValue(scriptGenerationConfig);
-			return AlterScriptDto.getInstance(script, true, false);
+			return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.alterEntity);
 		})
 		.filter(Boolean);
 };

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nonNullConstraintHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nonNullConstraintHelper.js
@@ -24,7 +24,7 @@ const getModifyNonNullColumnsScriptDtos = ({ scriptFormat, collection }) => {
 	const previousRequiredColumnNames = collection.role.required || [];
 
 	const addNotNullConstraintsScript = _.toPairs(collection.properties)
-		.map(([name, jsonSchema]) => {
+		.flatMap(([name, jsonSchema]) => {
 			const oldName = jsonSchema.compMod.oldField.name;
 
 			const newConstraintName = jsonSchema.notNullConstraintName || '';
@@ -43,8 +43,10 @@ const getModifyNonNullColumnsScriptDtos = ({ scriptFormat, collection }) => {
 
 			if (isOldRequired && (!isNewRequired || isNameChanged)) {
 				const template = oldConstraintName ? templates.dropConstraint : templates.alterNullableConstraint;
-				scripts.push(
+				AlterScriptDto.getInstance(
 					assignTemplates(template, { ...scriptParams, constraintName: prepareName(oldConstraintName) }),
+					true,
+					Boolean(oldConstraintName),
 				);
 			}
 
@@ -52,12 +54,14 @@ const getModifyNonNullColumnsScriptDtos = ({ scriptFormat, collection }) => {
 				const template = newConstraintName
 					? templates.alterNamedNotNullConstraint
 					: templates.alterNotNullConstraint;
-				scripts.push(
+				AlterScriptDto.getInstance(
 					assignTemplates(template, { ...scriptParams, constraintName: prepareName(newConstraintName) }),
+					true,
+					false,
 				);
 			}
 
-			return scripts.length ? AlterScriptDto.getInstance(scripts, true, false) : null;
+			return scripts;
 		})
 		.filter(Boolean);
 

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nonNullConstraintHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nonNullConstraintHelper.js
@@ -43,10 +43,12 @@ const getModifyNonNullColumnsScriptDtos = ({ scriptFormat, collection }) => {
 
 			if (isOldRequired && (!isNewRequired || isNameChanged)) {
 				const template = oldConstraintName ? templates.dropConstraint : templates.alterNullableConstraint;
-				AlterScriptDto.getInstance(
-					assignTemplates(template, { ...scriptParams, constraintName: prepareName(oldConstraintName) }),
-					true,
-					Boolean(oldConstraintName),
+				scripts.push(
+					AlterScriptDto.getInstance(
+						assignTemplates(template, { ...scriptParams, constraintName: prepareName(oldConstraintName) }),
+						true,
+						Boolean(templates.dropConstraint),
+					),
 				);
 			}
 
@@ -54,10 +56,12 @@ const getModifyNonNullColumnsScriptDtos = ({ scriptFormat, collection }) => {
 				const template = newConstraintName
 					? templates.alterNamedNotNullConstraint
 					: templates.alterNotNullConstraint;
-				AlterScriptDto.getInstance(
-					assignTemplates(template, { ...scriptParams, constraintName: prepareName(newConstraintName) }),
-					true,
-					false,
+				scripts.push(
+					AlterScriptDto.getInstance(
+						assignTemplates(template, { ...scriptParams, constraintName: prepareName(newConstraintName) }),
+						true,
+						false,
+					),
 				);
 			}
 

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nonNullConstraintHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/nonNullConstraintHelper.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const { assignTemplates } = require('../../../utils/assignTemplates');
 const templates = require('../../../ddlProvider/templates');
 const {
@@ -48,6 +48,7 @@ const getModifyNonNullColumnsScriptDtos = ({ scriptFormat, collection }) => {
 						assignTemplates(template, { ...scriptParams, constraintName: prepareName(oldConstraintName) }),
 						true,
 						Boolean(templates.dropConstraint),
+						SCRIPT_TYPE.alterEntity,
 					),
 				);
 			}
@@ -61,6 +62,7 @@ const getModifyNonNullColumnsScriptDtos = ({ scriptFormat, collection }) => {
 						assignTemplates(template, { ...scriptParams, constraintName: prepareName(newConstraintName) }),
 						true,
 						false,
+						SCRIPT_TYPE.alterEntity,
 					),
 				);
 			}

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/renameColumnHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/renameColumnHelper.js
@@ -21,9 +21,9 @@ const getRenameColumnScriptDtos = (ddlProvider, scriptFormat) => collection => {
 		.map(jsonSchema => {
 			const oldColumnName = prepareNameForScriptFormat(scriptFormat)(jsonSchema.compMod.oldField.name);
 			const newColumnName = prepareNameForScriptFormat(scriptFormat)(jsonSchema.compMod.newField.name);
-			return ddlProvider.renameColumn(fullName, oldColumnName, newColumnName);
-		})
-		.map(script => AlterScriptDto.getInstance([script], true, false));
+			const script = ddlProvider.renameColumn(fullName, oldColumnName, newColumnName);
+			return AlterScriptDto.getInstance(script, true, false);
+		});
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/renameColumnHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/columnHelpers/renameColumnHelper.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	checkFieldPropertiesChanged,
 	getEntityName,
@@ -22,7 +22,7 @@ const getRenameColumnScriptDtos = (ddlProvider, scriptFormat) => collection => {
 			const oldColumnName = prepareNameForScriptFormat(scriptFormat)(jsonSchema.compMod.oldField.name);
 			const newColumnName = prepareNameForScriptFormat(scriptFormat)(jsonSchema.compMod.newField.name);
 			const script = ddlProvider.renameColumn(fullName, oldColumnName, newColumnName);
-			return AlterScriptDto.getInstance(script, true, false);
+			return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.alterEntity);
 		});
 };
 

--- a/forward_engineering/alterScript/alterScriptHelpers/containerHelpers/alterSequenceHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/containerHelpers/alterSequenceHelper.js
@@ -19,7 +19,7 @@ const getAddContainerSequencesScriptDtos =
 			.map(sequence => {
 				const script = ddlProvider.createSchemaSequence({ schemaName, sequence });
 
-				return AlterScriptDto.getInstance([script], true, false);
+				return AlterScriptDto.getInstance(script, true, false);
 			})
 			.filter(Boolean);
 	};
@@ -45,13 +45,13 @@ const getModifyContainerSequencesScriptDtos =
 		const removedScriptDtos = removed.map(sequence => {
 			const script = ddlProvider.dropSchemaSequence({ schemaName, sequence });
 
-			return AlterScriptDto.getInstance([script], true, true);
+			return AlterScriptDto.getInstance(script, true, true);
 		});
 
 		const addedScriptDtos = added.map(sequence => {
 			const script = ddlProvider.createSchemaSequence({ schemaName, sequence });
 
-			return AlterScriptDto.getInstance([script], true, false);
+			return AlterScriptDto.getInstance(script, true, false);
 		});
 
 		const modifiedScriptDtos = modified.map(sequence => {
@@ -59,7 +59,7 @@ const getModifyContainerSequencesScriptDtos =
 			const script = ddlProvider.alterSchemaSequence({ schemaName, sequence, oldSequence });
 			const isDropScript = script.startsWith('DROP');
 
-			return AlterScriptDto.getInstance([script], true, isDropScript);
+			return AlterScriptDto.getInstance(script, true, isDropScript);
 		});
 
 		return [...modifiedScriptDtos, ...removedScriptDtos, ...addedScriptDtos].filter(Boolean);
@@ -79,7 +79,7 @@ const getDeleteContainerSequencesScriptDtos =
 			.map(sequence => {
 				const script = ddlProvider.dropSchemaSequence({ schemaName, sequence });
 
-				return AlterScriptDto.getInstance([script], true, true);
+				return AlterScriptDto.getInstance(script, true, true);
 			})
 			.filter(Boolean);
 	};

--- a/forward_engineering/alterScript/alterScriptHelpers/containerHelpers/alterSequenceHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/containerHelpers/alterSequenceHelper.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const { App } = require('../../../types/coreApplicationTypes');
 const { getDbName, getGroupItemsByCompMode } = require('../../../utils/general');
 
@@ -19,7 +19,7 @@ const getAddContainerSequencesScriptDtos =
 			.map(sequence => {
 				const script = ddlProvider.createSchemaSequence({ schemaName, sequence });
 
-				return AlterScriptDto.getInstance(script, true, false);
+				return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.alterContainer);
 			})
 			.filter(Boolean);
 	};
@@ -45,13 +45,13 @@ const getModifyContainerSequencesScriptDtos =
 		const removedScriptDtos = removed.map(sequence => {
 			const script = ddlProvider.dropSchemaSequence({ schemaName, sequence });
 
-			return AlterScriptDto.getInstance(script, true, true);
+			return AlterScriptDto.getInstance(script, true, true, SCRIPT_TYPE.alterContainer);
 		});
 
 		const addedScriptDtos = added.map(sequence => {
 			const script = ddlProvider.createSchemaSequence({ schemaName, sequence });
 
-			return AlterScriptDto.getInstance(script, true, false);
+			return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.alterContainer);
 		});
 
 		const modifiedScriptDtos = modified.map(sequence => {
@@ -59,7 +59,7 @@ const getModifyContainerSequencesScriptDtos =
 			const script = ddlProvider.alterSchemaSequence({ schemaName, sequence, oldSequence });
 			const isDropScript = script.startsWith('DROP');
 
-			return AlterScriptDto.getInstance(script, true, isDropScript);
+			return AlterScriptDto.getInstance(script, true, isDropScript, SCRIPT_TYPE.alterContainer);
 		});
 
 		return [...modifiedScriptDtos, ...removedScriptDtos, ...addedScriptDtos].filter(Boolean);
@@ -79,7 +79,7 @@ const getDeleteContainerSequencesScriptDtos =
 			.map(sequence => {
 				const script = ddlProvider.dropSchemaSequence({ schemaName, sequence });
 
-				return AlterScriptDto.getInstance(script, true, true);
+				return AlterScriptDto.getInstance(script, true, true, SCRIPT_TYPE.alterContainer);
 			})
 			.filter(Boolean);
 	};

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const { AlterCollectionDto } = require('../../types/AlterCollectionDto');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const { wrapInQuotes, getSchemaOfAlterCollection, getFullCollectionName } = require('../../../utils/general');
 const { assignTemplates } = require('../../../utils/assignTemplates');
 const templates = require('../../../ddlProvider/templates');
@@ -66,7 +66,7 @@ const getDropCheckConstraintScriptDtos = (constraintHistory, fullTableName) => {
 		.map(historyEntry => {
 			const wrappedConstraintName = wrapInQuotes(historyEntry.old.chkConstrName);
 			const script = dropConstraint(fullTableName, wrappedConstraintName);
-			return AlterScriptDto.getInstance(script, true, true);
+			return AlterScriptDto.getInstance(script, true, true, SCRIPT_TYPE.alterEntity);
 		});
 };
 
@@ -96,7 +96,7 @@ const getAddCheckConstraintScriptDtos = (constraintHistory, fullTableName) => {
 		.map(historyEntry => {
 			const { chkConstrName, constrExpression } = historyEntry.new;
 			const script = addCheckConstraint(fullTableName, wrapInQuotes(chkConstrName), constrExpression);
-			return AlterScriptDto.getInstance(script, true, false);
+			return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.alterEntity);
 		});
 };
 
@@ -127,8 +127,8 @@ const getUpdateCheckConstraintScriptDtos = (constraintHistory, fullTableName) =>
 			);
 
 			return [
-				AlterScriptDto.getInstance(dropConstraintScript, true, true),
-				AlterScriptDto.getInstance(addConstraintScript, true, false),
+				AlterScriptDto.getInstance(dropConstraintScript, true, true, SCRIPT_TYPE.alterEntity),
+				AlterScriptDto.getInstance(addConstraintScript, true, false, SCRIPT_TYPE.alterEntity),
 			];
 		});
 };

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/checkConstraintHelper.js
@@ -65,9 +65,9 @@ const getDropCheckConstraintScriptDtos = (constraintHistory, fullTableName) => {
 		.filter(historyEntry => historyEntry.old && !historyEntry.new)
 		.map(historyEntry => {
 			const wrappedConstraintName = wrapInQuotes(historyEntry.old.chkConstrName);
-			return dropConstraint(fullTableName, wrappedConstraintName);
-		})
-		.map(script => AlterScriptDto.getInstance([script], true, true));
+			const script = dropConstraint(fullTableName, wrappedConstraintName);
+			return AlterScriptDto.getInstance(script, true, true);
+		});
 };
 
 /**
@@ -95,9 +95,9 @@ const getAddCheckConstraintScriptDtos = (constraintHistory, fullTableName) => {
 		.filter(historyEntry => historyEntry.new && !historyEntry.old)
 		.map(historyEntry => {
 			const { chkConstrName, constrExpression } = historyEntry.new;
-			return addCheckConstraint(fullTableName, wrapInQuotes(chkConstrName), constrExpression);
-		})
-		.map(script => AlterScriptDto.getInstance([script], true, false));
+			const script = addCheckConstraint(fullTableName, wrapInQuotes(chkConstrName), constrExpression);
+			return AlterScriptDto.getInstance(script, true, false);
+		});
 };
 
 /**
@@ -115,7 +115,7 @@ const getUpdateCheckConstraintScriptDtos = (constraintHistory, fullTableName) =>
 			}
 			return false;
 		})
-		.map(historyEntry => {
+		.flatMap(historyEntry => {
 			const { chkConstrName: oldConstrainName } = historyEntry.old;
 			const dropConstraintScript = dropConstraint(fullTableName, wrapInQuotes(oldConstrainName));
 
@@ -127,11 +127,10 @@ const getUpdateCheckConstraintScriptDtos = (constraintHistory, fullTableName) =>
 			);
 
 			return [
-				AlterScriptDto.getInstance([dropConstraintScript], true, true),
-				AlterScriptDto.getInstance([addConstraintScript], true, false),
+				AlterScriptDto.getInstance(dropConstraintScript, true, true),
+				AlterScriptDto.getInstance(addConstraintScript, true, false),
 			];
-		})
-		.flat();
+		});
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/commentsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/commentsHelper.js
@@ -1,4 +1,4 @@
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const { AlterCollectionDto } = require('../../types/AlterCollectionDto');
 const { assignTemplates } = require('../../../utils/assignTemplates');
 const { wrapComment, getSchemaOfAlterCollection, getFullCollectionName } = require('../../../utils/general');
@@ -40,7 +40,7 @@ const getUpdatedCommentOnCollectionScriptDto = ({ scriptFormat, collection }) =>
 	const comment = newComment ? wrapComment(newComment) : 'NULL';
 	const script = updateTableComment(fullTableName, comment);
 
-	return AlterScriptDto.getInstance(script, true, false);
+	return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.alterEntity);
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/commentsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/commentsHelper.js
@@ -40,7 +40,7 @@ const getUpdatedCommentOnCollectionScriptDto = ({ scriptFormat, collection }) =>
 	const comment = newComment ? wrapComment(newComment) : 'NULL';
 	const script = updateTableComment(fullTableName, comment);
 
-	return AlterScriptDto.getInstance([script], true, false);
+	return AlterScriptDto.getInstance(script, true, false);
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto.js');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto.js');
 const { AlterCollectionDto } = require('../../types/AlterCollectionDto');
 const { AlterIndexDto } = require('../../types/AlterIndexDto');
 const { prepareNameForScriptFormat } = require('../../../utils/general.js');
@@ -139,7 +139,7 @@ const getDeleteIndexScriptDto =
 		const name = prepareNameForScriptFormat(scriptFormat)(index.indxName);
 		const script = ddlProvider.dropIndex({ name });
 
-		return AlterScriptDto.getInstance(script, index.isActivated, true);
+		return AlterScriptDto.getInstance(script, index.isActivated, true, SCRIPT_TYPE.dropEntityIndex);
 	};
 
 /**
@@ -177,7 +177,7 @@ const getAddIndexScriptDto =
 			schemaName: collection?.role?.compMod?.bucketProperties?.name,
 		});
 
-		return AlterScriptDto.getInstance(script, index.isActivated, false);
+		return AlterScriptDto.getInstance(script, index.isActivated, false, SCRIPT_TYPE.createEntityIndex);
 	};
 
 /**
@@ -228,6 +228,7 @@ const getModifyIndexScriptDto =
 				ddlProvider.dropIndex({ name: oldName }),
 				newIndex.isActivated,
 				true,
+				SCRIPT_TYPE.dropEntityIndex,
 			);
 			const newIndexWithAddedKeyNames = addNameToIndexKey({ index: newIndex, collection });
 			const createIndexDto = AlterScriptDto.getInstance(
@@ -237,6 +238,7 @@ const getModifyIndexScriptDto =
 				}),
 				newIndex.isActivated,
 				false,
+				SCRIPT_TYPE.createEntityIndex,
 			);
 			alterScriptDtos.push(dropIndexDto, createIndexDto);
 
@@ -249,6 +251,7 @@ const getModifyIndexScriptDto =
 				ddlProvider.alterIndexRename({ oldName, newName }),
 				newIndex.isActivated,
 				false,
+				SCRIPT_TYPE.alterEntityIndex,
 			);
 			alterScriptDtos.push(alterIndexDto);
 		}
@@ -258,6 +261,7 @@ const getModifyIndexScriptDto =
 				ddlProvider.alterIndexRebuild({ name: newName, indexData: newIndex }),
 				newIndex.isActivated,
 				false,
+				SCRIPT_TYPE.alterEntityIndex,
 			);
 			alterScriptDtos.push(alterIndexRebuildDto);
 		}

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/indexesHelper.js
@@ -139,7 +139,7 @@ const getDeleteIndexScriptDto =
 		const name = prepareNameForScriptFormat(scriptFormat)(index.indxName);
 		const script = ddlProvider.dropIndex({ name });
 
-		return AlterScriptDto.getInstance([script], index.isActivated, true);
+		return AlterScriptDto.getInstance(script, index.isActivated, true);
 	};
 
 /**
@@ -161,7 +161,7 @@ const getAddedIndexesScriptDtos =
 			return !correspondingOldIndex;
 		});
 
-		return addedIndexes.map(index => getAddIndexScriptDto({ ddlProvider })({ index, collection }));
+		return addedIndexes.map(index => getAddIndexScriptDto({ ddlProvider })({ index, collection })).filter(Boolean);
 	};
 
 /**
@@ -177,7 +177,7 @@ const getAddIndexScriptDto =
 			schemaName: collection?.role?.compMod?.bucketProperties?.name,
 		});
 
-		return AlterScriptDto.getInstance([script], index.isActivated, false);
+		return AlterScriptDto.getInstance(script, index.isActivated, false);
 	};
 
 /**
@@ -225,18 +225,16 @@ const getModifyIndexScriptDto =
 
 		if (shouldDropAndRecreateIndex({ oldIndex, newIndex })) {
 			const dropIndexDto = AlterScriptDto.getInstance(
-				[ddlProvider.dropIndex({ name: oldName })],
+				ddlProvider.dropIndex({ name: oldName }),
 				newIndex.isActivated,
 				true,
 			);
 			const newIndexWithAddedKeyNames = addNameToIndexKey({ index: newIndex, collection });
 			const createIndexDto = AlterScriptDto.getInstance(
-				[
-					ddlProvider.createIndex(collection?.role?.compMod?.collectionName?.new, {
-						...newIndexWithAddedKeyNames,
-						schemaName: collection?.role?.compMod?.bucketProperties?.name,
-					}),
-				],
+				ddlProvider.createIndex(collection?.role?.compMod?.collectionName?.new, {
+					...newIndexWithAddedKeyNames,
+					schemaName: collection?.role?.compMod?.bucketProperties?.name,
+				}),
 				newIndex.isActivated,
 				false,
 			);
@@ -248,7 +246,7 @@ const getModifyIndexScriptDto =
 		const shouldRenameIndex = oldIndex.indxName !== newIndex.indxName;
 		if (shouldRenameIndex) {
 			const alterIndexDto = AlterScriptDto.getInstance(
-				[ddlProvider.alterIndexRename({ oldName, newName })],
+				ddlProvider.alterIndexRename({ oldName, newName }),
 				newIndex.isActivated,
 				false,
 			);
@@ -257,7 +255,7 @@ const getModifyIndexScriptDto =
 
 		if (shouldAlterIndexRebuild({ oldIndex, newIndex })) {
 			const alterIndexRebuildDto = AlterScriptDto.getInstance(
-				[ddlProvider.alterIndexRebuild({ name: newName, indexData: newIndex })],
+				ddlProvider.alterIndexRebuild({ name: newName, indexData: newIndex }),
 				newIndex.isActivated,
 				false,
 			);

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
@@ -1,4 +1,4 @@
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const { AlterCollectionDto } = require('../../types/AlterCollectionDto');
 const { assignTemplates } = require('../../../utils/assignTemplates');
 const {
@@ -37,7 +37,7 @@ const getRenameCollectionScriptDto = ({ scriptFormat, collection }) => {
 		newName: prepareNameForScriptFormat(scriptFormat)(newName),
 	});
 
-	return AlterScriptDto.getInstance(script, true, false);
+	return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.alterEntity);
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/nameHelper.js
@@ -37,7 +37,7 @@ const getRenameCollectionScriptDto = ({ scriptFormat, collection }) => {
 		newName: prepareNameForScriptFormat(scriptFormat)(newName),
 	});
 
-	return AlterScriptDto.getInstance([script], true, false);
+	return AlterScriptDto.getInstance(script, true, false);
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
@@ -489,7 +489,7 @@ const getModifyPkConstraintsScriptDtos = ({ scriptFormat, collection }) => {
 	const sortedAllDtos = sortModifyKeyConstraints(allDtos);
 
 	return sortedAllDtos
-		.map(dto => AlterScriptDto.getInstance([dto.script], dto.isActivated, dto.isDropScript))
+		.map(dto => AlterScriptDto.getInstance(dto.script, dto.isActivated, dto.isDropScript))
 		.filter(Boolean);
 };
 

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	AlterCollectionDto,
 	AlterCollectionColumnDto,
@@ -488,7 +488,9 @@ const getModifyPkConstraintsScriptDtos = ({ scriptFormat, collection }) => {
 	const allDtos = [...modifyCompositePkScriptDtos, ...modifyPkScriptDtos].filter(Boolean);
 	const sortedAllDtos = sortModifyKeyConstraints(allDtos);
 
-	return sortedAllDtos;
+	return sortedAllDtos.map(dto =>
+		AlterScriptDto.getInstance(dto.script, dto.isActivated, dto.isDropScript, SCRIPT_TYPE.alterEntity),
+	);
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/primaryKeyHelper.js
@@ -485,12 +485,10 @@ const getModifyPkConstraintsScriptDtos = ({ scriptFormat, collection }) => {
 	const modifyCompositePkScriptDtos = getModifyCompositePkScriptDtos({ scriptFormat, collection });
 	const modifyPkScriptDtos = getModifyPkScriptDtos({ scriptFormat, collection });
 
-	const allDtos = [...modifyCompositePkScriptDtos, ...modifyPkScriptDtos];
+	const allDtos = [...modifyCompositePkScriptDtos, ...modifyPkScriptDtos].filter(Boolean);
 	const sortedAllDtos = sortModifyKeyConstraints(allDtos);
 
-	return sortedAllDtos
-		.map(dto => AlterScriptDto.getInstance(dto.script, dto.isActivated, dto.isDropScript))
-		.filter(Boolean);
+	return sortedAllDtos;
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
@@ -499,12 +499,10 @@ const getModifyUniqueKeyConstraintsScriptDtos = ({ scriptFormat, collection }) =
 	const modifyCompositeUniqueKeyScriptDtos = getModifyCompositeUniqueKeyScriptDtos({ scriptFormat, collection });
 	const modifyUniqueKeyScriptDtos = getModifyUniqueKeyScriptDtos({ scriptFormat, collection });
 
-	const allDtos = [...modifyCompositeUniqueKeyScriptDtos, ...modifyUniqueKeyScriptDtos];
+	const allDtos = [...modifyCompositeUniqueKeyScriptDtos, ...modifyUniqueKeyScriptDtos].filter(Boolean);
 	const sortedAllDtos = sortModifyKeyConstraints(allDtos);
 
-	return sortedAllDtos
-		.map(dto => AlterScriptDto.getInstance(dto.script, dto.isActivated, dto.isDropScript))
-		.filter(Boolean);
+	return sortedAllDtos;
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
@@ -503,7 +503,7 @@ const getModifyUniqueKeyConstraintsScriptDtos = ({ scriptFormat, collection }) =
 	const sortedAllDtos = sortModifyKeyConstraints(allDtos);
 
 	return sortedAllDtos
-		.map(dto => AlterScriptDto.getInstance([dto.script], dto.isActivated, dto.isDropScript))
+		.map(dto => AlterScriptDto.getInstance(dto.script, dto.isActivated, dto.isDropScript))
 		.filter(Boolean);
 };
 

--- a/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/entityHelpers/uniqueKeyHelper.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const {
 	AlterCollectionDto,
 	AlterCollectionColumnDto,
@@ -502,7 +502,9 @@ const getModifyUniqueKeyConstraintsScriptDtos = ({ scriptFormat, collection }) =
 	const allDtos = [...modifyCompositeUniqueKeyScriptDtos, ...modifyUniqueKeyScriptDtos].filter(Boolean);
 	const sortedAllDtos = sortModifyKeyConstraints(allDtos);
 
-	return sortedAllDtos;
+	return sortedAllDtos.map(dto =>
+		AlterScriptDto.getInstance(dto.script, dto.isActivated, dto.isDropScript, SCRIPT_TYPE.alterEntity),
+	);
 };
 
 module.exports = {

--- a/forward_engineering/alterScript/alterScriptHelpers/viewHelpers/commentsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/viewHelpers/commentsHelper.js
@@ -1,4 +1,4 @@
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const { wrapComment, getNamePrefixedWithSchemaNameForScriptFormat } = require('../../../utils/general');
 const { assignTemplates } = require('../../../utils/assignTemplates');
 const templates = require('../../../ddlProvider/templates');
@@ -34,7 +34,7 @@ const getUpdatedCommentScriptDto = ({ scriptFormat, view }) => {
 	const wrappedComment = description.new ? wrapComment(description.new) : 'NULL';
 	const script = updateViewComment(fullViewName, wrappedComment, view.materialized);
 
-	return AlterScriptDto.getInstance(script, true, false);
+	return AlterScriptDto.getInstance(script, true, false, SCRIPT_TYPE.alterView);
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/viewHelpers/commentsHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/viewHelpers/commentsHelper.js
@@ -34,7 +34,7 @@ const getUpdatedCommentScriptDto = ({ scriptFormat, view }) => {
 	const wrappedComment = description.new ? wrapComment(description.new) : 'NULL';
 	const script = updateViewComment(fullViewName, wrappedComment, view.materialized);
 
-	return AlterScriptDto.getInstance([script], true, false);
+	return AlterScriptDto.getInstance(script, true, false);
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/viewHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/viewHelpers/nameHelper.js
@@ -1,4 +1,4 @@
-const { AlterScriptDto } = require('../../types/AlterScriptDto');
+const { AlterScriptDto, SCRIPT_TYPE } = require('../../types/AlterScriptDto');
 const { AlterCollectionDto } = require('../../types/AlterCollectionDto');
 const { assignTemplates } = require('../../../utils/assignTemplates');
 const { prepareNameForScriptFormat } = require('../../../utils/general');
@@ -28,7 +28,7 @@ const getRenameEntityScriptDto = ({ scriptFormat, entity }) => {
 		newName: prepareNameForScriptFormat(scriptFormat)(newName),
 	});
 
-	return AlterScriptDto.getInstance(renameScript, true, false);
+	return AlterScriptDto.getInstance(renameScript, true, false, SCRIPT_TYPE.alterView);
 };
 
 /**

--- a/forward_engineering/alterScript/alterScriptHelpers/viewHelpers/nameHelper.js
+++ b/forward_engineering/alterScript/alterScriptHelpers/viewHelpers/nameHelper.js
@@ -28,7 +28,7 @@ const getRenameEntityScriptDto = ({ scriptFormat, entity }) => {
 		newName: prepareNameForScriptFormat(scriptFormat)(newName),
 	});
 
-	return AlterScriptDto.getInstance([renameScript], true, false);
+	return AlterScriptDto.getInstance(renameScript, true, false);
 };
 
 /**

--- a/forward_engineering/alterScript/types/AlterScriptDto.js
+++ b/forward_engineering/alterScript/types/AlterScriptDto.js
@@ -21,13 +21,14 @@ class AlterScriptDto {
 	 * @return {AlterScriptDto | undefined}
 	 * */
 	static getInstance(script, isActivated, isDropScript) {
-		if (!script?.trim()) {
+		const cleanScript = script?.trim();
+		if (!cleanScript) {
 			return undefined;
 		}
 		return {
 			isActivated,
 			isDropScript,
-			scripts: script.trim(),
+			script: cleanScript,
 		};
 	}
 }

--- a/forward_engineering/alterScript/types/AlterScriptDto.js
+++ b/forward_engineering/alterScript/types/AlterScriptDto.js
@@ -1,7 +1,27 @@
+const SCRIPT_TYPE = /** @type {const} */ ({
+	createContainer: 'CREATE_CONTAINER',
+	dropContainer: 'DROP_CONTAINER',
+	alterContainer: 'ALTER_CONTAINER',
+	createEntity: 'CREATE_ENTITY',
+	dropEntity: 'DROP_ENTITY',
+	alterEntity: 'ALTER_ENTITY',
+	createView: 'CREATE_VIEW',
+	dropView: 'DROP_VIEW',
+	alterView: 'ALTER_VIEW',
+	createForeignKey: 'CREATE_FOREIGN_KEY',
+	dropForeignKey: 'DROP_FOREIGN_KEY',
+	createUDT: 'CREATE_UDT',
+	dropUDT: 'CREATE_UDT',
+	alterUDT: 'CREATE_UDT',
+	createEntityIndex: 'CREATE_ENTITY_INDEX',
+	dropEntityIndex: 'DROP_ENTITY_INDEX',
+	alterEntityIndex: 'ALTER_ENTITY_INDEX',
+});
+
 class AlterScriptDto {
 	/**
 	 * @type {boolean | undefined}
-	 * */
+	 */
 	isActivated;
 
 	/**
@@ -11,8 +31,18 @@ class AlterScriptDto {
 
 	/**
 	 * @type {string}
-	 * */
+	 */
 	script;
+
+	/**
+	 * @type {typeof SCRIPT_TYPE[keyof typeof SCRIPT_TYPE] | null}
+	 */
+	scriptType;
+
+	/**
+	 * @type {string | null}
+	 */
+	entityId;
 
 	/**
 	 * @param {string} script
@@ -20,19 +50,22 @@ class AlterScriptDto {
 	 * @param {boolean} isDropScripts
 	 * @return {AlterScriptDto | undefined}
 	 * */
-	static getInstance(script, isActivated, isDropScript) {
+	static getInstance(script, isActivated, isDropScript, scriptType, entityId) {
 		const cleanScript = script?.trim();
 		if (!cleanScript) {
-			return undefined;
+			return null;
 		}
 		return {
 			isActivated,
 			isDropScript,
 			script: cleanScript,
+			scriptType,
+			entityId,
 		};
 	}
 }
 
 module.exports = {
 	AlterScriptDto,
+	SCRIPT_TYPE,
 };

--- a/forward_engineering/alterScript/types/AlterScriptDto.js
+++ b/forward_engineering/alterScript/types/AlterScriptDto.js
@@ -1,15 +1,3 @@
-class ModificationScript {
-	/**
-	 * @type {string}
-	 * */
-	script;
-
-	/**
-	 * @type {boolean}
-	 * */
-	isDropScript;
-}
-
 class AlterScriptDto {
 	/**
 	 * @type {boolean | undefined}
@@ -17,81 +5,33 @@ class AlterScriptDto {
 	isActivated;
 
 	/**
-	 * @type {Array<ModificationScript>}
+	 * @type {boolean}
 	 * */
-	scripts;
+	isDropScript;
 
 	/**
-	 * @param {Array<string>} scripts
-	 * @param {boolean} isActivated
-	 * @param {boolean} isDropScripts
-	 * @return {Array<AlterScriptDto>}
+	 * @type {string}
 	 * */
-	static getInstances(scripts, isActivated, isDropScripts) {
-		return (scripts || []).filter(Boolean).map(script => ({
-			isActivated,
-			scripts: [
-				{
-					isDropScript: isDropScripts,
-					script,
-				},
-			],
-		}));
-	}
+	script;
 
 	/**
-	 * @param {Array<string>} scripts
+	 * @param {string} script
 	 * @param {boolean} isActivated
 	 * @param {boolean} isDropScripts
 	 * @return {AlterScriptDto | undefined}
 	 * */
-	static getInstance(scripts, isActivated, isDropScripts) {
-		if (!scripts?.filter(Boolean)?.length) {
+	static getInstance(script, isActivated, isDropScript) {
+		if (!script?.trim()) {
 			return undefined;
 		}
 		return {
 			isActivated,
-			scripts: scripts.filter(Boolean).map(script => ({
-				isDropScript: isDropScripts,
-				script,
-			})),
-		};
-	}
-
-	/**
-	 * @param {string | undefined} dropScript
-	 * @param {string | undefined} createScript
-	 * @param {boolean} isActivated
-	 * @return {AlterScriptDto | undefined}
-	 * */
-	static getDropAndRecreateInstance(dropScript, createScript, isActivated) {
-		/**
-		 * @type {ModificationScript[]}
-		 * */
-		const scriptModificationDtos = [];
-		if (dropScript) {
-			scriptModificationDtos.push({
-				isDropScript: true,
-				script: dropScript,
-			});
-		}
-		if (createScript) {
-			scriptModificationDtos.push({
-				isDropScript: false,
-				script: createScript,
-			});
-		}
-		if (!scriptModificationDtos?.length) {
-			return undefined;
-		}
-		return {
-			isActivated,
-			scripts: scriptModificationDtos,
+			isDropScript,
+			scripts: script.trim(),
 		};
 	}
 }
 
 module.exports = {
-	ModificationScript,
 	AlterScriptDto,
 };

--- a/forward_engineering/utils/general.js
+++ b/forward_engineering/utils/general.js
@@ -233,6 +233,8 @@ const isParentContainerActivated = collection => {
 	);
 };
 
+const getId = entity => entity.id || entity.role.id;
+
 module.exports = {
 	getDbName,
 	getBucketName,
@@ -262,4 +264,5 @@ module.exports = {
 	getSchemaOfAlterCollection,
 	isObjectInDeltaModelActivated,
 	isParentContainerActivated,
+	getId,
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14858" title="HCK-14858" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-14858</a>  [Oracle]: Update ALTER script generation to return array of fragments 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

1. `AlterDtoScript` contains a single statement now (`scripts` => `script`).
2. Update all locations where `getInstance` is used so it accepts a single string of a single statement.
3. Remove redundant cycles (`.map()`).
4. Add the `keepDtos` flag to return object statements or a string for backward compatibility.
5. Extend `AlterDtoScript` with the `scriptType` and `entityId` properties that will be used by custom script hooks.
     Currently, `entityId` is added only to the newly created items.