### PR TITLE
chore: unified annotation keywords

### DIFF
--- a/forward_engineering/ddlProvider/ddlHelpers/tableHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/tableHelper.js
@@ -1,22 +1,8 @@
 const _ = require('lodash');
+const { getAnnotationsString } = require('../../utils/getAnnotationsString');
 
-module.exports = ({
-	getColumnsList,
-	checkAllKeysDeactivated,
-	commentIfDeactivated,
-	prepareName,
-	assignTemplates,
-	wrapComment,
-}) => {
-	const getTableType = ({
-		duplicated,
-		external,
-		immutable,
-		sharded,
-		temporary,
-		temporaryType,
-		blockchain_table_clauses,
-	}) => {
+module.exports = ({ getColumnsList, checkAllKeysDeactivated, commentIfDeactivated, prepareName }) => {
+	const getTableType = ({ duplicated, immutable, sharded, temporary, temporaryType, blockchain_table_clauses }) => {
 		const blockchain = !_.isEmpty(blockchain_table_clauses);
 		switch (true) {
 			case temporary:
@@ -43,7 +29,7 @@ module.exports = ({
 			{ key: 'partitioning', getValue: getPartitioning },
 			{ key: 'selectStatement', getValue: getBasicValue('AS') },
 			{ key: 'tableProperties', getValue: value => _.trim(value) },
-			{ key: 'tableAnnotations', getValue: getAnnotationsString },
+			{ key: 'tableAnnotations', getValue: getAnnotationsString(prepareName) },
 		]
 			.map(config => (tableData[config.key] ? wrap(config.getValue(tableData[config.key], tableData)) : ''))
 			.filter(Boolean)
@@ -301,40 +287,6 @@ module.exports = ({
 	const customPropertiesForForeignKey = relationship => {
 		const foreignOnDelete = _.get(relationship, 'relationshipOnDelete', '');
 		return { foreignOnDelete };
-	};
-
-	/**
-	 * Generates annotations string.
-	 * @param {Array} tableAnnotations - tableAnnotations array.
-	 * @returns {string} - Annotation string (e.g: "\nANNOTATIONS (...)") or ''.
-	 */
-	const getAnnotationsString = tableAnnotations => {
-		if (!Array.isArray(tableAnnotations) || tableAnnotations.length === 0) {
-			return '';
-		}
-
-		const wrapValue = value => wrapComment(value);
-
-		const annotationsItems = tableAnnotations
-			.filter(annotation => annotation?.annotationName?.trim())
-			.map(annotation => {
-				const { annotationName, annotationValue } = annotation;
-				const name = prepareName(annotationName.trim());
-
-				let finalValue = '';
-
-				if (annotationValue !== undefined && annotationValue.trim() !== '') {
-					finalValue = ' ' + wrapValue(annotationValue.trim());
-				}
-
-				return `${name}${finalValue}`;
-			});
-
-		if (annotationsItems.length > 0) {
-			return `ANNOTATIONS (${annotationsItems.join(', ')})`;
-		}
-
-		return '';
 	};
 
 	return {

--- a/forward_engineering/ddlProvider/ddlHelpers/tableHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/tableHelper.js
@@ -316,15 +316,15 @@ module.exports = ({
 		const wrapValue = value => wrapComment(value);
 
 		const annotationsItems = tableAnnotations
-			.filter(annotation => annotation?.tableAnnotationName?.trim())
+			.filter(annotation => annotation?.annotationName?.trim())
 			.map(annotation => {
-				const name = prepareName(annotation.tableAnnotationName.trim());
+				const { annotationName, annotationValue } = annotation;
+				const name = prepareName(annotationName.trim());
 
 				let finalValue = '';
-				const annotationValue = annotation?.tableAnnotationValue;
 
-				if (annotationValue !== undefined && String(annotationValue).trim() !== '') {
-					finalValue = ' ' + wrapValue(String(annotationValue).trim());
+				if (annotationValue !== undefined && annotationValue.trim() !== '') {
+					finalValue = ' ' + wrapValue(annotationValue.trim());
 				}
 
 				return `${name}${finalValue}`;

--- a/forward_engineering/utils/getAnnotationsString.js
+++ b/forward_engineering/utils/getAnnotationsString.js
@@ -1,0 +1,44 @@
+const { wrapComment } = require('./general');
+
+/**
+ * @typedef {{
+ *   annotationName?: string
+ *   annotationValue?: string
+ * }} Annotation
+ */
+
+/**
+ * Generates annotations string.
+ * @param {function} prepareName
+ * @returns {(annotations: Annotation[]) => string} - returns Annotations string (e.g: "\nANNOTATIONS (...)") or ''.
+ */
+const getAnnotationsString = prepareName => annotations => {
+	if (!Array.isArray(annotations) || annotations.length === 0) {
+		return '';
+	}
+
+	const wrapValue = value => wrapComment(value);
+
+	const annotationsItems = annotations
+		.filter(annotation => annotation?.annotationName?.trim())
+		.map(annotation => {
+			const { annotationName, annotationValue } = annotation;
+			const name = prepareName(annotationName.trim());
+
+			let finalValue = '';
+
+			if (annotationValue !== undefined && annotationValue.trim() !== '') {
+				finalValue = ' ' + wrapValue(annotationValue.trim());
+			}
+
+			return `${name}${finalValue}`;
+		});
+
+	if (annotationsItems.length > 0) {
+		return `ANNOTATIONS (${annotationsItems.join(', ')})`;
+	}
+
+	return '';
+};
+
+module.exports = { getAnnotationsString };

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -912,7 +912,7 @@ making sure that you maintain a proper JSON format.
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "tableAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -921,7 +921,7 @@ making sure that you maintain a proper JSON format.
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "tableAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",
@@ -1234,7 +1234,7 @@ making sure that you maintain a proper JSON format.
 						"structure": [
 							{
 								"propertyName": "Name",
-								"propertyKeyword": "indexAnnotationName",
+								"propertyKeyword": "annotationName",
 								"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 								"propertyType": "text",
 								"validation": {
@@ -1243,7 +1243,7 @@ making sure that you maintain a proper JSON format.
 							},
 							{
 								"propertyName": "Value",
-								"propertyKeyword": "indexAnnotationValue",
+								"propertyKeyword": "annotationValue",
 								"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 								"propertyType": "details",
 								"template": "textarea",

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -2128,7 +2128,7 @@ making sure that you maintain a proper JSON format.
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "columnAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -2137,7 +2137,7 @@ making sure that you maintain a proper JSON format.
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "columnAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",
@@ -4162,7 +4162,7 @@ making sure that you maintain a proper JSON format.
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "columnAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -4171,7 +4171,7 @@ making sure that you maintain a proper JSON format.
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "columnAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",
@@ -5948,7 +5948,7 @@ making sure that you maintain a proper JSON format.
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "columnAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -5957,7 +5957,7 @@ making sure that you maintain a proper JSON format.
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "columnAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",
@@ -6777,7 +6777,7 @@ making sure that you maintain a proper JSON format.
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "columnAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -6786,7 +6786,7 @@ making sure that you maintain a proper JSON format.
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "columnAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",
@@ -8007,7 +8007,7 @@ making sure that you maintain a proper JSON format.
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "columnAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -8016,7 +8016,7 @@ making sure that you maintain a proper JSON format.
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "columnAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",
@@ -9435,7 +9435,7 @@ making sure that you maintain a proper JSON format.
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "columnAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -9444,7 +9444,7 @@ making sure that you maintain a proper JSON format.
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "columnAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",
@@ -11106,7 +11106,7 @@ making sure that you maintain a proper JSON format.
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "columnAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -11115,7 +11115,7 @@ making sure that you maintain a proper JSON format.
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "columnAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",
@@ -11283,7 +11283,7 @@ making sure that you maintain a proper JSON format.
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "columnAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -11292,7 +11292,7 @@ making sure that you maintain a proper JSON format.
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "columnAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",
@@ -12157,7 +12157,7 @@ making sure that you maintain a proper JSON format.
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "columnAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -12166,7 +12166,7 @@ making sure that you maintain a proper JSON format.
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "columnAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",
@@ -12699,7 +12699,7 @@ making sure that you maintain a proper JSON format.
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "columnAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -12708,7 +12708,7 @@ making sure that you maintain a proper JSON format.
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "columnAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",
@@ -13485,7 +13485,7 @@ making sure that you maintain a proper JSON format.
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "columnAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -13494,7 +13494,7 @@ making sure that you maintain a proper JSON format.
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "columnAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",
@@ -14039,7 +14039,7 @@ making sure that you maintain a proper JSON format.
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "columnAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -14048,7 +14048,7 @@ making sure that you maintain a proper JSON format.
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "columnAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",

--- a/properties_pane/view_level/viewLevelConfig.json
+++ b/properties_pane/view_level/viewLevelConfig.json
@@ -703,7 +703,7 @@
 				"structure": [
 					{
 						"propertyName": "Name",
-						"propertyKeyword": "viewAnnotationName",
+						"propertyKeyword": "annotationName",
 						"propertyTooltip": "An identifier that can have up to 1024 characters. If the annotation name is a reserved word it must be provided in double quotes. When a double quoted identifier is used, the identifier can also contain whitespace characters",
 						"propertyType": "text",
 						"validation": {
@@ -712,7 +712,7 @@
 					},
 					{
 						"propertyName": "Value",
-						"propertyKeyword": "viewAnnotationValue",
+						"propertyKeyword": "annotationValue",
 						"propertyTooltip": "The value of the annotation is optionsal.  Value can have a maximum of 4000 characters.",
 						"propertyType": "details",
 						"template": "textarea",


### PR DESCRIPTION
## Content

* unified annotation keywords
* removed redundant String cast, as the type is definied by the `"propertyType": "details",` and will always be string