### PR TITLE
HCK-15041: add annotations filtering for versions 12c and 18c

### DIFF
--- a/forward_engineering/ddlProvider/ddlHelpers/dualityViewFeHelper/abstractDualityViewDdlCreator.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/dualityViewFeHelper/abstractDualityViewDdlCreator.js
@@ -183,13 +183,14 @@ class AbstractDualityViewFeDdlCreator {
 	getCreateJsonRelationalDualityViewHeadingDdl(createViewDto, prepareName) {
 		const { jsonSchema, view } = createViewDto;
 		const template = this._ddlTemplates?.dualityView?.createJsonRelationalDualityViewHeading || '';
+		const dbVersion = view?.modelInfo?.dbVersion || '';
 
 		const orReplaceStatement = this._getOrReplaceStatement(view);
 		const forceStatement = this._getForceStatement(jsonSchema);
 		const editionableStatement = this._getEditionableStatement(jsonSchema);
 		const viewName = getViewName(view);
 		const ddlViewName = this._getNamePrefixedWithSchemaName(viewName, view.schemaName);
-		const annotations = getAnnotationsString(prepareName)(view.viewAnnotations);
+		const annotations = getAnnotationsString(prepareName, dbVersion)(view.viewAnnotations);
 
 		const params = {
 			orReplaceStatement,

--- a/forward_engineering/ddlProvider/ddlHelpers/tableHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/tableHelper.js
@@ -29,7 +29,7 @@ module.exports = ({ getColumnsList, checkAllKeysDeactivated, commentIfDeactivate
 			{ key: 'partitioning', getValue: getPartitioning },
 			{ key: 'selectStatement', getValue: getBasicValue('AS') },
 			{ key: 'tableProperties', getValue: value => _.trim(value) },
-			{ key: 'tableAnnotations', getValue: getAnnotationsString(prepareName) },
+			{ key: 'tableAnnotations', getValue: getAnnotationsString(prepareName, tableData?.dbVersion) },
 		]
 			.map(config => (tableData[config.key] ? wrap(config.getValue(tableData[config.key], tableData)) : ''))
 			.filter(Boolean)

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -143,7 +143,7 @@ module.exports = (baseProvider, options, app) => {
 			const emptyLineSeparator = '\n\n';
 			const statementTerminator = ';';
 
-			const annotations = getAnnotationsString(prepareName)(schemaAnnotations);
+			const annotations = getAnnotationsString(prepareName, dbVersion)(schemaAnnotations);
 			const finalAnnotationsClause = annotations ? ' ' + annotations : '';
 			const preparedSchemaName = prepareName(schemaName);
 			const usingTryCatchWrapper = shouldUseTryCatchIfNotExistsWrapper(dbVersion);
@@ -226,8 +226,9 @@ module.exports = (baseProvider, options, app) => {
 		},
 
 		convertColumnDefinition(columnDefinition, template = templates.columnDefinition) {
-			const type = replaceTypeByVersion(columnDefinition.type, columnDefinition.dbVersion);
-			const annotations = getAnnotationsString(prepareName)(columnDefinition.columnAnnotations);
+			const dbVersion = columnDefinition?.dbVersion;
+			const type = replaceTypeByVersion(columnDefinition.type, dbVersion);
+			const annotations = getAnnotationsString(prepareName, dbVersion)(columnDefinition.columnAnnotations);
 			const finalAnnotationsClause = annotations ? ' ' + annotations : '';
 
 			return commentIfDeactivated(
@@ -484,6 +485,7 @@ module.exports = (baseProvider, options, app) => {
 					selectStatement,
 					tableProperties,
 					tableAnnotations,
+					dbVersion,
 				}),
 			});
 			if (usingTryCatchWrapper) {
@@ -514,7 +516,7 @@ module.exports = (baseProvider, options, app) => {
 			const dbVersion = options.dbVersion || '';
 			const usingTryCatchWrapper = shouldUseTryCatchIfNotExistsWrapper(dbVersion);
 
-			const annotations = getAnnotationsString(prepareName)(index.indexAnnotations);
+			const annotations = getAnnotationsString(prepareName, dbVersion)(index.indexAnnotations);
 			const finalAnnotationsClause = annotations ? ' ' + annotations : '';
 
 			const shouldInsertIfNotExistsStatement = index.ifNotExist && !usingTryCatchWrapper;
@@ -668,7 +670,7 @@ module.exports = (baseProvider, options, app) => {
 			const dbVersion = _.get(viewData, 'modelInfo.dbVersion', '');
 			const usingTryCatchWrapper = shouldUseTryCatchIfNotExistsWrapper(dbVersion);
 
-			const annotations = getAnnotationsString(prepareName)(viewData.viewAnnotations);
+			const annotations = getAnnotationsString(prepareName, dbVersion)(viewData.viewAnnotations);
 
 			let createViewDdl = assignTemplates(templates.createView, {
 				name: viewName,

--- a/forward_engineering/utils/getAnnotationsString.js
+++ b/forward_engineering/utils/getAnnotationsString.js
@@ -7,12 +7,19 @@ const { wrapComment } = require('./general');
  * }} Annotation
  */
 
+const UNSUPPORTED_DB_VERSIONS = new Set(['12c', '18c']);
+
 /**
  * Generates annotations string.
- * @param {function} prepareName
+ * @param {function} prepareName - Function to format/escape identifiers
+ * @param {string} [dbVersion] - Database version
  * @returns {(annotations: Annotation[]) => string} - returns Annotations string (e.g: "\nANNOTATIONS (...)") or ''.
  */
-const getAnnotationsString = prepareName => annotations => {
+const getAnnotationsString = (prepareName, dbVersion) => annotations => {
+	if (!dbVersion || UNSUPPORTED_DB_VERSIONS.has(dbVersion)) {
+		return '';
+	}
+
 	if (!Array.isArray(annotations) || annotations.length === 0) {
 		return '';
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-15041" title="HCK-15041" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-15041</a>  [Oracle][Annotations] Lowering the version of Oracle does not remove added annotations from DDL Script
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Oracle supports annotations for version 19 and above. 
Added annotations clauses filtering for version 12c and 18c. 