### PR TITLE
HCK-15041: add user warning modal

### DIFF
--- a/forward_engineering/ddlProvider/ddlHelpers/dualityViewFeHelper/abstractDualityViewDdlCreator.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/dualityViewFeHelper/abstractDualityViewDdlCreator.js
@@ -183,14 +183,13 @@ class AbstractDualityViewFeDdlCreator {
 	getCreateJsonRelationalDualityViewHeadingDdl(createViewDto, prepareName) {
 		const { jsonSchema, view } = createViewDto;
 		const template = this._ddlTemplates?.dualityView?.createJsonRelationalDualityViewHeading || '';
-		const dbVersion = view?.modelInfo?.dbVersion || '';
 
 		const orReplaceStatement = this._getOrReplaceStatement(view);
 		const forceStatement = this._getForceStatement(jsonSchema);
 		const editionableStatement = this._getEditionableStatement(jsonSchema);
 		const viewName = getViewName(view);
 		const ddlViewName = this._getNamePrefixedWithSchemaName(viewName, view.schemaName);
-		const annotations = getAnnotationsString(prepareName, dbVersion)(view.viewAnnotations);
+		const annotations = getAnnotationsString(prepareName)(view.viewAnnotations);
 
 		const params = {
 			orReplaceStatement,

--- a/forward_engineering/ddlProvider/ddlHelpers/tableHelper.js
+++ b/forward_engineering/ddlProvider/ddlHelpers/tableHelper.js
@@ -29,7 +29,7 @@ module.exports = ({ getColumnsList, checkAllKeysDeactivated, commentIfDeactivate
 			{ key: 'partitioning', getValue: getPartitioning },
 			{ key: 'selectStatement', getValue: getBasicValue('AS') },
 			{ key: 'tableProperties', getValue: value => _.trim(value) },
-			{ key: 'tableAnnotations', getValue: getAnnotationsString(prepareName, tableData?.dbVersion) },
+			{ key: 'tableAnnotations', getValue: getAnnotationsString(prepareName) },
 		]
 			.map(config => (tableData[config.key] ? wrap(config.getValue(tableData[config.key], tableData)) : ''))
 			.filter(Boolean)

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -143,7 +143,7 @@ module.exports = (baseProvider, options, app) => {
 			const emptyLineSeparator = '\n\n';
 			const statementTerminator = ';';
 
-			const annotations = getAnnotationsString(prepareName, dbVersion)(schemaAnnotations);
+			const annotations = getAnnotationsString(prepareName)(schemaAnnotations);
 			const finalAnnotationsClause = annotations ? ' ' + annotations : '';
 			const preparedSchemaName = prepareName(schemaName);
 			const usingTryCatchWrapper = shouldUseTryCatchIfNotExistsWrapper(dbVersion);
@@ -228,7 +228,7 @@ module.exports = (baseProvider, options, app) => {
 		convertColumnDefinition(columnDefinition, template = templates.columnDefinition) {
 			const dbVersion = columnDefinition?.dbVersion;
 			const type = replaceTypeByVersion(columnDefinition.type, dbVersion);
-			const annotations = getAnnotationsString(prepareName, dbVersion)(columnDefinition.columnAnnotations);
+			const annotations = getAnnotationsString(prepareName)(columnDefinition.columnAnnotations);
 			const finalAnnotationsClause = annotations ? ' ' + annotations : '';
 
 			return commentIfDeactivated(
@@ -485,7 +485,6 @@ module.exports = (baseProvider, options, app) => {
 					selectStatement,
 					tableProperties,
 					tableAnnotations,
-					dbVersion,
 				}),
 			});
 			if (usingTryCatchWrapper) {
@@ -516,7 +515,7 @@ module.exports = (baseProvider, options, app) => {
 			const dbVersion = options.dbVersion || '';
 			const usingTryCatchWrapper = shouldUseTryCatchIfNotExistsWrapper(dbVersion);
 
-			const annotations = getAnnotationsString(prepareName, dbVersion)(index.indexAnnotations);
+			const annotations = getAnnotationsString(prepareName)(index.indexAnnotations);
 			const finalAnnotationsClause = annotations ? ' ' + annotations : '';
 
 			const shouldInsertIfNotExistsStatement = index.ifNotExist && !usingTryCatchWrapper;
@@ -670,7 +669,7 @@ module.exports = (baseProvider, options, app) => {
 			const dbVersion = _.get(viewData, 'modelInfo.dbVersion', '');
 			const usingTryCatchWrapper = shouldUseTryCatchIfNotExistsWrapper(dbVersion);
 
-			const annotations = getAnnotationsString(prepareName, dbVersion)(viewData.viewAnnotations);
+			const annotations = getAnnotationsString(prepareName)(viewData.viewAnnotations);
 
 			let createViewDdl = assignTemplates(templates.createView, {
 				name: viewName,

--- a/forward_engineering/utils/getAnnotationsString.js
+++ b/forward_engineering/utils/getAnnotationsString.js
@@ -7,19 +7,12 @@ const { wrapComment } = require('./general');
  * }} Annotation
  */
 
-const UNSUPPORTED_DB_VERSIONS = new Set(['12c', '18c']);
-
 /**
  * Generates annotations string.
  * @param {function} prepareName - Function to format/escape identifiers
- * @param {string} [dbVersion] - Database version
  * @returns {(annotations: Annotation[]) => string} - returns Annotations string (e.g: "\nANNOTATIONS (...)") or ''.
  */
-const getAnnotationsString = (prepareName, dbVersion) => annotations => {
-	if (!dbVersion || UNSUPPORTED_DB_VERSIONS.has(dbVersion)) {
-		return '';
-	}
-
+const getAnnotationsString = prepareName => annotations => {
 	if (!Array.isArray(annotations) || annotations.length === 0) {
 		return '';
 	}

--- a/properties_pane/model_level/modelLevelConfig.json
+++ b/properties_pane/model_level/modelLevelConfig.json
@@ -113,7 +113,6 @@ making sure that you maintain a proper JSON format.
 			}
 
 */
-
 [
 	{
 		"lowerTab": "Details",
@@ -171,6 +170,21 @@ making sure that you maintain a proper JSON format.
 							]
 						},
 						"adapter": "adaptUnavailableTypes"
+					},
+					{
+						"dependency": {
+							"type": "or",
+							"values": [
+								{
+									"key": "dbVersion",
+									"value": "12c"
+								},
+								{
+									"key": "dbVersion",
+									"value": "18c"
+								}
+							]
+						}
 					}
 				]
 			},

--- a/properties_pane/model_level/modelLevelConfig.json
+++ b/properties_pane/model_level/modelLevelConfig.json
@@ -184,7 +184,8 @@ making sure that you maintain a proper JSON format.
 									"value": "18c"
 								}
 							]
-						}
+						},
+						"adapter": "adaptOracleAnnotationsForLegacy"
 					}
 				]
 			},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-15041" title="HCK-15041" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-15041</a>  [Oracle][Annotations] Lowering the version of Oracle does not remove added annotations from DDL Script
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

- refactor getAnnotationsString to remove dbVersion parameter
- updated the getAnnotationsString function to eliminate the dbVersion parameter, simplifying the annotation generation process across various components. 
- updated `properties_pane/model_level/modelLevelConfig.json` , use `"adapter": "adaptOracleAnnotationsForLegacy"`